### PR TITLE
Check whether ground state is in levels when creating NLevelSpace

### DIFF
--- a/src/nlevel.jl
+++ b/src/nlevel.jl
@@ -23,7 +23,12 @@ struct NLevelSpace{S,L,G} <: ConcreteHilbertSpace
     name::S
     levels::L
     GS::G
+    function NLevelSpace{S,L,G}(name::S, levels::L, GS::G) where {S,L,G}
+        (GS ∈ levels) || throw(ArgumentError("Ground state $GS not in levels $levels"))
+        return new(name, levels, GS)
+    end
 end
+NLevelSpace(name::S, levels::L, GS::G) where {S,L,G} = NLevelSpace{S,L,G}(name, levels, GS)
 NLevelSpace(name,N::Int,GS) = NLevelSpace(name,1:N,GS)
 NLevelSpace(name,N::Int) = NLevelSpace(name,1:N,1)
 NLevelSpace(name,levels) = NLevelSpace(name,levels,levels[1])

--- a/test/test_nlevel.jl
+++ b/test/test_nlevel.jl
@@ -64,4 +64,6 @@ s = Transition(hprod,:σ,1)
 @test s(:g,:e) == σ1
 @test acts_on(Transition(ha2,:s))==1
 
+@test_throws ArgumentError NLevelSpace(:atom, (:g,:e), 1)
+
 end # testset


### PR DESCRIPTION
Just fell into this trap and only noticed when `Transition(h,:s,:g,:g)` wasn't getting replaced in the equations.