### PR TITLE
Add missing istree method for QTerm types

### DIFF
--- a/src/qnumber.jl
+++ b/src/qnumber.jl
@@ -42,6 +42,9 @@ Base.isless(a::QSym, b::QSym) = a.name < b.name
 ## Interface for SymbolicUtils
 
 TermInterface.exprhead(::QNumber) = :call
+TermInterface.istree(::QSym) = false
+TermInterface.istree(::QTerm) = true
+TermInterface.istree(::Type{T}) where {T<:QTerm} = true
 
 # Symbolic type promotion
 SymbolicUtils.promote_symtype(f, Ts::Type{<:QNumber}...) = promote_type(Ts...)
@@ -51,9 +54,6 @@ SymbolicUtils.promote_symtype(f,T::Type{<:Number},S::Type{<:QNumber}) = S
 SymbolicUtils.promote_symtype(f,T::Type{<:QNumber},S::Type{<:QNumber}) = promote_type(T,S)
 
 SymbolicUtils.symtype(x::T) where T<:QNumber = T
-
-SymbolicUtils.istree(::QSym) = false
-SymbolicUtils.istree(::QTerm) = true
 
 # Standard simplify
 function SymbolicUtils.simplify(x::QNumber;kwargs...)

--- a/test/test_fock.jl
+++ b/test/test_fock.jl
@@ -29,4 +29,16 @@ H = ωc*a'*a
 da = simplify(1.0im*(H*a - a*H))
 @test isequal(da , (0.0-1.0im)*ωc*a)
 
+# Test substitute by numbers
+@syms x
+@test iszero(substitute(x*a, Dict(x=>0)))
+@test isequal(substitute(x*a, Dict(x=>1)), a)
+@test iszero(substitute(x*a, Dict(a=>0)))
+
+# Test substitute by syms
+@syms y
+@test isequal(substitute(x*a, Dict(x=>y)), y*a)
+@test isequal(substitute(x*a, Dict(a=>y)), x*y)
+@test isequal(substitute(x*(a+a'), Dict(x => y)), y*(a + a'))
+
 end # testset


### PR DESCRIPTION
We were missing the `istree(::Type{<:QTerm})=true` method, so `similarterm` returned the wrong thing. This lead to errors in `substitute` (see also #93).