### PR TITLE
Fix and simplify to_numeric

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -358,8 +358,6 @@ function check_basis_match(h::ProductSpace, b::QuantumOpticsBase.CompositeBasis)
     end
 end
 
-# function check_basis_match
-
 # Composite bases
 function to_numeric(op::QSym, b::QuantumOpticsBase.CompositeBasis; kwargs...)
     check_basis_match(op.hilbert, b)
@@ -372,23 +370,7 @@ end
 function to_numeric(op::QTerm, b::QuantumOpticsBase.Basis; kwargs...)
     f = SymbolicUtils.operation(op)
     args = SymbolicUtils.arguments(op)
-    if f === (*)
-        if isone(args[1])
-            deleteat!(args, 1)
-        end
-        op_num = one(b)
-        tmp = QuantumOpticsBase.SparseOperator(b)
-        for arg ∈ args
-            mul!(tmp, op_num, to_numeric(arg, b; kwargs...))
-            op_num = tmp
-        end
-    else
-        op_num = to_numeric(args[1], b; kwargs...)
-        for arg ∈ args[2:end]
-            op_num = f(op_num, to_numeric(arg, b; kwargs...))
-        end
-    end
-    return op_num
+    return f((to_numeric(arg, b; kwargs...) for arg in args)...)
 end
 
 function to_numeric(x::Number, b::QuantumOpticsBase.Basis; kwargs...)

--- a/test/test_numeric_conversion.jl
+++ b/test/test_numeric_conversion.jl
@@ -105,5 +105,14 @@ u0 = initial_values(eqs, ψ0; level_map=level_map)
 @test u0[4] ≈ expect(one(bcav) ⊗ transition(batom, 2, 2), ψ0)
 @test u0[5] ≈ expect(create(bcav) ⊗ transition(batom, 1, 2), ψ0)
 
+# Test sufficiently large hilbert space; from issue #109
+hfock = FockSpace(:fock)
+@qnumbers a::Destroy(hfock)
+bfock = FockBasis(100)
+
+diff = (2*create(bfock)+2*destroy(bfock)) - to_numeric((2*(a)+2*(a')), bfock)
+@assert iszero(diff)
+
+@assert iszero(to_numeric(2*a, bfock) - 2*to_numeric(a, bfock))
 
 end # testset


### PR DESCRIPTION
Fixes #109.

The problem was the alias in the multiplication
```julia
mul!(tmp, op_num, to_numeric(arg, b; kwargs...))
op_num = tmp
```
It should have been `op_num = copy(tmp)`. Anyway, I simplified it altogether to avoid such mistakes in the future.