### PR TITLE
Renaming of method names for Indexing

### DIFF
--- a/docs/src/examples/cavity_antiresonance_indexed.md
+++ b/docs/src/examples/cavity_antiresonance_indexed.md
@@ -5,11 +5,11 @@ The Hamiltonian of this system is composed of three parts $H = H_c + H_a + H_{\m
 
 ```math
 \begin{align*}
-H_\mathrm{c} &= \Delta_c a^\dagger a + \eta (a^\dagger + a) \\
-&\\
-H_a &= \Delta_a \sum\limits_{j} \sigma_j^{22} + \sum\limits_{i \neq j} \Omega_{ij} \sigma_i^{21} \sigma_j^{12} \\
-&\\
-H_\mathrm{int} &= \sum\limits_{j} g_j (a^\dagger \sigma_j^{12} + a \sigma_j^{21})
+H_\mathrm{c} = \Delta_c a^\dagger a + \eta (a^\dagger + a) \\
+\\
+H_a = \Delta_a \sum\limits_{i} \sigma_i^{22} + \sum\limits_{i \neq j} \Omega_{ij} \sigma_i^{21} \sigma_j^{12} \\
+\\
+H_\mathrm{int} = \sum\limits_{i} g_i (a^\dagger \sigma_i^{12} + a \sigma_i^{21})
 \end{align*}
 ```
 
@@ -23,6 +23,7 @@ We start by loading the packages.
 using QuantumCumulants
 using OrdinaryDiffEq, SteadyStateDiffEq, ModelingToolkit
 using Plots
+nothing #hide
 ```
 
 The Hilbert space for this system is given by one cavity mode and $N$ two-level atoms and the parameters $g_j, \, \Gamma_{ij}$ and $\Omega_{ij}$ are defined as **IndexedVariable** of atom $i$ and $j$. We will describe the system in first order mean-field.
@@ -44,19 +45,18 @@ k = Index(h,:k,N,ha)
 N_n = 2 #number of atoms
 
 #define indexed variables
-g(k) = IndexedVariable(:g,k)
+gi = IndexedVariable(:g,i)
 Γ_ij = IndexedVariable(:Γ,i,j)  
-Ω_ij = IndexedVariable(:Ω,i,j,false) #false indicates that the 2 indices can never be the same
+Ω_ij = IndexedVariable(:Ω,i,j;can_have_same=false) #false indicates that the 2 indices can never be the same
 nothing #hide
 ```
-
 
 Now we create the operators on the composite Hilbert space using a **IndexedOperator** constructor to assign each **Transition** operator an index $k$.
 
 
 ```@example cavity_antiresonance_indexed
 @qnumbers a::Destroy(h)
-σ(i,j,k) = IndexedOperator(Transition(h,:σ,i,j),k)
+σ(x,y,k) = IndexedOperator(Transition(h,:σ,x,y),k)
 nothing #hide
 ```
 
@@ -70,41 +70,39 @@ $\dot{\mathcal{O}} = \sum_{ij} R_{ij} (J_i^\dagger \mathcal{O} J_j - J_i^\dagger
 # Hamiltonian
 Hc = Δc*a'a + η*(a' + a)
 
-Ha = Δa*Σ(σ(2,2,i),i) + Σ(Ω_ij*σ(2,1,i)*σ(1,2,j),j,i,true)
+Ha = Δa*Σ(σ(2,2,i),i) + Σ(Ω_ij*σ(2,1,i)*σ(1,2,j),j,i)
 
-Hi = Σ(g(i)*(a'*σ(1,2,i) + a*σ(2,1,i)),i)
+Hi = Σ(gi*(a'*σ(1,2,i) + a*σ(2,1,i)),i)
 H = Hc + Ha + Hi
 
 # Jump operators & and rates
-J = [a, [σ(1,2,i),σ(1,2,j)] ]
+J = [a, [σ(1,2,i),σ(1,2,j)] ] 
 rates = [κ,Γ_ij]
 nothing #hide
 ```
 
-
-Using the Hamiltonina and Liouvillian we derive the system of equations in first order mean-field.
+Using the Hamiltonian and Liouvillian we derive the system of equations in first order mean-field.
 
 
 
 ```@example cavity_antiresonance_indexed
 ops = [a, σ(2,2,k), σ(1,2,k)]
-eqs = indexedMeanfield(ops,H,J;rates=rates,order=order)
+eqs = indexed_meanfield(ops,H,J;rates=rates,order=order)
 nothing #hide
 ```
 
 ```math
 \begin{align}
 \frac{d}{dt} \langle a\rangle  =& -1 i \eta -1 i \underset{i}{\overset{N}{\sum}} {g}_{i}  \langle {\sigma}_{i}^{{12}}\rangle  -1 i {\Delta}c \langle a\rangle  -0.5 \kappa \langle a\rangle  \\
-\frac{d}{dt} \langle {\sigma}_{k}^{{22}}\rangle  =& -0.5 \underset{i{\ne}j,k}{\overset{N}{\sum}} {\Gamma}_{ik}  \langle {\sigma}_{k}^{{12}}\rangle   \langle {\sigma}_{i}^{{21}}\rangle  -0.5 \underset{j{\ne}k}{\overset{N}{\sum}} {\Gamma}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle   \langle {\sigma}_{k}^{{21}}\rangle  + 1 i \underset{i{\ne}j,k}{\overset{N}{\sum}} {\Omega}_{ik}  \langle {\sigma}_{k}^{{12}}\rangle   \langle {\sigma}_{i}^{{21}}\rangle  -1 i \underset{j{\ne}i,k}{\overset{N}{\sum}} {\Omega}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle   \langle {\sigma}_{k}^{{21}}\rangle  -1.0 {\Gamma}_{kk} \langle {\sigma}_{k}^{{22}}\rangle  + 1 i {g}_{k} \langle a^\dagger\rangle  \langle {\sigma}_{k}^{{12}}\rangle  -1 i {g}_{k} \langle a\rangle  \langle {\sigma}_{k}^{{21}}\rangle  \\
-\frac{d}{dt} \langle {\sigma}_{k}^{{12}}\rangle  =& \underset{j{\ne}k}{\overset{N}{\sum}} {\Gamma}_{kj}  \langle {\sigma}_{k}^{{22}}\rangle   \langle {\sigma}_{j}^{{12}}\rangle  -0.5 \underset{j}{\overset{N}{\sum}} {\Gamma}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle  -1 i \underset{j{\ne}i,k}{\overset{N}{\sum}} {\Omega}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle  + 2 i \underset{j{\ne}i,k}{\overset{N}{\sum}} {\Omega}_{kj}  \langle {\sigma}_{k}^{{22}}\rangle   \langle {\sigma}_{j}^{{12}}\rangle  -1 i {g}_{k} \langle a\rangle  -1 i {\Delta}a \langle {\sigma}_{k}^{{12}}\rangle  + 2 i {g}_{k} \langle a\rangle  \langle {\sigma}_{k}^{{22}}\rangle
+\frac{d}{dt} \langle {\sigma}_{k}^{{22}}\rangle  =& -0.5 \underset{i{\ne}j,k}{\overset{N}{\sum}} {\Gamma}_{ik}  \langle {\sigma}_{i}^{{21}}\rangle   \langle {\sigma}_{k}^{{12}}\rangle  -0.5 \underset{j{\ne}k}{\overset{N}{\sum}} {\Gamma}_{kj}  \langle {\sigma}_{k}^{{21}}\rangle   \langle {\sigma}_{j}^{{12}}\rangle  + 1 i \underset{i{\ne}j,k}{\overset{N}{\sum}} {\Omega}_{ik}  \langle {\sigma}_{i}^{{21}}\rangle   \langle {\sigma}_{k}^{{12}}\rangle  -1 i \underset{j{\ne}i,k}{\overset{N}{\sum}} {\Omega}_{kj}  \langle {\sigma}_{k}^{{21}}\rangle   \langle {\sigma}_{j}^{{12}}\rangle  -1.0 {\Gamma}_{kk} \langle {\sigma}_{k}^{{22}}\rangle  -1 i {g}_{k} \langle a\rangle  \langle {\sigma}_{k}^{{21}}\rangle  + 1 i {g}_{k} \langle a^\dagger\rangle  \langle {\sigma}_{k}^{{12}}\rangle  \\
+\frac{d}{dt} \langle {\sigma}_{k}^{{12}}\rangle  =& \underset{j{\ne}k}{\overset{N}{\sum}} {\Gamma}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle   \langle {\sigma}_{k}^{{22}}\rangle  -1 i \underset{j{\ne}i,k}{\overset{N}{\sum}} {\Omega}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle  -0.5 \underset{j}{\overset{N}{\sum}} {\Gamma}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle  + 2 i \underset{j{\ne}i,k}{\overset{N}{\sum}} {\Omega}_{kj}  \langle {\sigma}_{j}^{{12}}\rangle   \langle {\sigma}_{k}^{{22}}\rangle  -1 i {g}_{k} \langle a\rangle  -1 i {\Delta}a \langle {\sigma}_{k}^{{12}}\rangle  + 2 i {g}_{k} \langle a\rangle  \langle {\sigma}_{k}^{{22}}\rangle 
 \end{align}
 ```
 
 We complete the set of equations automatically.
 
-
 ```@example cavity_antiresonance_indexed
-eqs_comp = complete(eqs;extraIndices=[:q])
+eqs_comp = complete(eqs;extra_indices=[:q])
 nothing #hide
 ```
 
@@ -112,7 +110,7 @@ We now evaluate the symbolic indices inside these equations to their numerical v
 
 
 ```@example cavity_antiresonance_indexed
-eqs_ = evaluate(eqs_comp;mapping=(N=>N_n)); #use the numerical value of N in mapping keyword
+eqs_ = evaluate(eqs_comp;mapping=(N=>N_n)) #use the numerical value of N in mapping keyword
 @named sys = ODESystem(eqs_)
 nothing #hide
 ```
@@ -142,7 +140,7 @@ g_ = 2Γ_
 η_ = κ_/100
 
 g_v = [g_*(-1)^j for j=1:N_n]
-ps = [Δc, η, Δa, κ, g(j), Γ_ij, Ω_ij]
+ps = [Δc, η, Δa, κ, gi, Γ_ij, Ω_ij]
 nothing #hide
 ```
 
@@ -157,7 +155,7 @@ for i=1:length(Δ_ls)
     Δc_i = Δ_ls[i]
     Δa_i = Δc_i + Ωij_(1,2) #cavity on resonace with the shifted collective emitter
     p0_i = [Δc_i, η_, Δa_i, κ_, g_v, ΓMatrix, ΩMatrix]
-    ps_ = createMap(ps,p0_i;mapping=(N=>N_n)) #Combine all the parameters + values to one list for solving
+    ps_ = value_map(ps,p0_i;mapping=(N=>N_n)) #Combine all the parameters + values to one list for solving
     prob = ODEProblem(sys,u0,(0.0, 20Γ_), ps_);
     prob_ss = SteadyStateProblem(prob);
     sol_ss = solve(prob_ss, DynamicSS(Tsit5(); abstol=1e-8, reltol=1e-8),
@@ -171,7 +169,7 @@ nothing #hide
 ```@example cavity_antiresonance_indexed
 T = n_ls ./ maximum(n_ls)
 p = plot(Δ_ls, T, xlabel="Δ/Γ", ylabel="T", legend=false)
-savefig("antiresonance_indexed.svg") # hide
+savefig("cavity_antiresonance_indexed.svg") # hide
 ```
 
-![svg](antiresonance_indexed.svg)
+![svg](cavity_antiresonance_indexed.svg)

--- a/src/QuantumCumulants.jl
+++ b/src/QuantumCumulants.jl
@@ -32,10 +32,10 @@ export HilbertSpace, ProductSpace, ⊗, tensor,
         scale,
         transition_superscript, 
         Index, reorder, IndexedOperator, IndexedSingleSum, IndexedVariable, DoubleIndexedVariable,
-        IndexedDoubleSum, createValueMap, indexedComplete, indexedCorrelationFunction,
-        scaleME, evalME, indexedComplete!, indexedMeanfield, substReds, AvgSums, plotME,
-        IndexedAverageSum, IndexedAverageDoubleSum, SpecialIndexedTerm, findMissingSumTerms, Σ,
-        evaluate, createMap, NumberedOperator, changeIndex, orderByIndex, splitSums, insertIndex, evalTerm
+        IndexedDoubleSum, indexed_complete, IndexedCorrelationFunction,
+        scaleME, evalME, indexed_complete!, indexed_meanfield, subst_reds, AvgSums, plotME,
+        IndexedAverageSum, IndexedAverageDoubleSum, SpecialIndexedTerm, find_missing_sums, Σ,
+        evaluate, value_map, NumberedOperator, change_index, order_by_index, split_sums, insert_index, eval_term
 
 const NO_METADATA = SymbolicUtils.NO_METADATA
 

--- a/src/doubleSums.jl
+++ b/src/doubleSums.jl
@@ -40,14 +40,14 @@ struct IndexedDoubleSum <:QTerm
                         continue
                     end
                     if index != sumIndex && index ∉ NEI && isequal(index.specHilb,sumIndex.specHilb)
-                        extraterm = IndexedSingleSum(changeIndex(innerSum.term,sumIndex,index),innerSum.sumIndex,innerSum.nonEqualIndices)
+                        extraterm = IndexedSingleSum(change_index(innerSum.term,sumIndex,index),innerSum.sumIndex,innerSum.nonEqualIndices)
                         push!(NEI_,index)
                     end 
                 end
                 if innerSum.term isa QMul
                     # put terms of the outer index in front
                     indicesToOrder = sort([innerSum.sumIndex,sumIndex],by=getIndName)
-                    newargs = orderByIndex(innerSum.term.args_nc,indicesToOrder)
+                    newargs = order_by_index(innerSum.term.args_nc,indicesToOrder)
                     qmul = 0
                     if length(newargs) == 1
                         qmul = *(innerSum.term.arg_c,newargs[1])
@@ -84,8 +84,8 @@ function IndexedDoubleSum(term::QMul,ind::Vector{Index},NEI::Vector{Index})
     end
     return IndexedDoubleSum(IndexedSingleSum(term,ind[1],NEI),ind[2],NEI)
 end
-function IndexedDoubleSum(term::QMul,outerInd::Index,innerInd::Index,ne::Bool)
-    if ne
+function IndexedDoubleSum(term::QMul,outerInd::Index,innerInd::Index;non_equal::Bool=false)
+    if non_equal
         innerSum = IndexedSingleSum(term,innerInd,[outerInd])
         return IndexedDoubleSum(innerSum,outerInd,[])
     else
@@ -137,7 +137,7 @@ function *(elem,sum::IndexedDoubleSum)
         if elem.ind != sum.sumIndex && elem.ind ∉ NEI
             if ((sum.sumIndex.specHilb != sum.innerSum.sumIndex.specHilb) && isequal(elem.ind.specHilb,sum.sumIndex.specHilb))
                 push!(NEI,elem.ind) 
-                addterm = IndexedSingleSum(elem*changeIndex(sum.innerSum.term,sum.sumIndex,elem.ind),sum.innerSum.sumIndex,sum.innerSum.nonEqualIndices)
+                addterm = IndexedSingleSum(elem*change_index(sum.innerSum.term,sum.sumIndex,elem.ind),sum.innerSum.sumIndex,sum.innerSum.nonEqualIndices)
                 return IndexedDoubleSum(elem*sum.innerSum,sum.sumIndex,NEI) + addterm
             end
         end
@@ -150,7 +150,7 @@ function *(sum::IndexedDoubleSum,elem)
         if elem.ind != sum.sumIndex && elem.ind ∉ NEI
             if ((sum.sumIndex.specHilb != sum.innerSum.sumIndex.specHilb) && isequal(elem.ind.specHilb,sum.sumIndex.specHilb))
                 push!(NEI,elem.ind)
-                addterm = IndexedSingleSum(changeIndex(sum.innerSum.term,sum.sumIndex,elem.ind)*elem,sum.innerSum.sumIndex,sum.innerSum.nonEqualIndices)
+                addterm = IndexedSingleSum(change_index(sum.innerSum.term,sum.sumIndex,elem.ind)*elem,sum.innerSum.sumIndex,sum.innerSum.nonEqualIndices)
                 return IndexedDoubleSum(sum.innerSum*elem,sum.sumIndex,NEI) + addterm
             end
         end
@@ -183,7 +183,7 @@ function *(sum1::IndexedSingleSum,sum2::IndexedSingleSum; ind=nothing)
         if !(ind isa Index)
             error("Specification of an extra Index is needed!")
         end
-        term2 = changeIndex(sum2.term,sum2.sumIndex,ind)
+        term2 = change_index(sum2.term,sum2.sumIndex,ind)
         return IndexedDoubleSum(IndexedSingleSum(sum1.term*term2,sum1.sumIndex,sum1.nonEqualIndices),ind,sum1.nonEqualIndices)
 
     end

--- a/test/test_average_sums.jl
+++ b/test/test_average_sums.jl
@@ -15,10 +15,13 @@ h = hf⊗ha
 ind(i) = Index(h,i,N,ha)
 
 g(k) = IndexedVariable(:g,k)
-Γij = DoubleIndexedVariable(:Γ,ind(:i),ind(:j),true)
+Γij = DoubleIndexedVariable(:Γ,ind(:i),ind(:j))
 σ(i,j,k) = IndexedOperator(Transition(h,:σ,i,j),k)
 
 σn(i,j,k) = NumberedOperator(Transition(h,:σ,i,j),k)
+Ω(i,j) = IndexedVariable(:Ω,i,j;can_have_same=false)
+
+@test Ω(ind(:i),ind(:i)) == 0
 
 a = Destroy(h,:a)
 
@@ -28,27 +31,27 @@ a = Destroy(h,:a)
 
 sum1 = IndexedSingleSum(σ(1,2,ind(:k)),ind(:k))
 σn(i,j,k) = NumberedOperator(Transition(h,:σ,i,j),k)
-@test(isequal(evalTerm(average(sum1)),average(σn(1,2,1)) + average(σn(1,2,2))))
+@test(isequal(eval_term(average(sum1)),average(σn(1,2,1)) + average(σn(1,2,2))))
 @test(isequal(σn(1,2,1)+σn(2,1,1),NumberedOperator(Transition(h,:σ,1,2)+Transition(h,:σ,2,1),1)))
 
-#test insertIndex
-@test(isequal(σn(2,2,1),insertIndex(σ(2,2,ind(:j)),ind(:j),1)))
-@test(isequal(σ(1,2,ind(:j)),insertIndex(σ(1,2,ind(:j)),ind(:k),2)))
-@test(isequal(1,insertIndex(1,ind(:k),1)))
+#test insert_index
+@test(isequal(σn(2,2,1),insert_index(σ(2,2,ind(:j)),ind(:j),1)))
+@test(isequal(σ(1,2,ind(:j)),insert_index(σ(1,2,ind(:j)),ind(:k),2)))
+@test(isequal(1,insert_index(1,ind(:k),1)))
 
 sum2 = average(sum1*σ(1,2,ind(:l)))
 
-@test(!isequal(σn(2,2,1),insertIndex(sum2,ind(:j),1)))
+@test(!isequal(σn(2,2,1),insert_index(sum2,ind(:j),1)))
 
 
-gamma = insertIndex(Γij,ind(:i),1)
-gamma2 = insertIndex(Γij,ind(:j),2)
-gamma2_ = insertIndex(Γij,ind(:i),1)
-g_ = insertIndex(g(ind(:j)),ind(:j),1)
+gamma = insert_index(Γij,ind(:i),1)
+gamma2 = insert_index(Γij,ind(:j),2)
+gamma2_ = insert_index(Γij,ind(:i),1)
+g_ = insert_index(g(ind(:j)),ind(:j),1)
 @test g_ isa SymbolicUtils.Sym
 @test gamma isa SymbolicUtils.Sym{Parameter,qc.numberedVariable}
 
-gamma_ = insertIndex(gamma,ind(:j),2)
+gamma_ = insert_index(gamma,ind(:j),2)
 @test gamma_ isa SymbolicUtils.Sym
 
 @test !isequal(gamma,gamma_)
@@ -104,13 +107,13 @@ specAvrg = qc.SpecialIndexedAverage(average(σ(2,1,ind(:i))*σ(1,2,ind(:j))),[(i
 @test isequal(SymbolicUtils.arguments(SymbolicUtils.arguments(SymbolicUtils.arguments(ADsum1)[1])),SymbolicUtils.arguments(average(σ(2,1,ind(:i))*σ(1,2,ind(:j)))))
 @test isequal(SymbolicUtils.arguments(specAvrg),SymbolicUtils.arguments(average(σ(2,1,ind(:i))*σ(1,2,ind(:j)))))
 
-@test isequal(σ(1,2,ind(:j))*σn(1,2,2),qc.insertIndex(σ(1,2,ind(:i))*σ(1,2,ind(:j)),ind(:i),2))
+@test isequal(σ(1,2,ind(:j))*σn(1,2,2),qc.insert_index(σ(1,2,ind(:i))*σ(1,2,ind(:j)),ind(:i),2))
 
 vec1 = qc.appendEach([1,2,3],[3,4,5])
 vec2 = [[1, 3], [1, 4], [1, 5], [2, 3], [2, 4], [2, 5], [3, 3], [3, 4], [3, 5]]
 @test isequal(vec1,vec2)
 
-dict_ = qc.createValueMap(g(ind(:i)),2)
+dict_ = qc.create_value_map(g(ind(:i)),2)
 dict = Dict{SymbolicUtils.Sym{Parameter, Base.ImmutableDict{DataType, Any}},ComplexF64}()
 push!(dict,(qc.SingleNumberedVariable(:g,1) => 2))
 push!(dict,(qc.SingleNumberedVariable(:g,2) => 2))

--- a/test/test_double_sums.jl
+++ b/test/test_double_sums.jl
@@ -41,7 +41,7 @@ k_ind = Index(h,:k,N_modes,hf)
 l_ind = Index(h,:l,N_modes,hf)
 
 
-g_ik = DoubleIndexedVariable(:g,i_ind,k_ind,true)
+g_ik = IndexedVariable(:g,i_ind,k_ind)
 
 a(k) = IndexedOperator(Destroy(h,:a),k)
 σ(i,j,k) = IndexedOperator(Transition(h,Symbol("σ"),i,j),k)
@@ -78,15 +78,15 @@ Dsum2 = H.arguments[2]
 ADsum1 = average(DSum1)
 ADsum2 = average(Dsum2)
 
-split0 = splitSums(ADsum1,j_ind,15)
+split0 = split_sums(ADsum1,j_ind,15)
 @test isequal(split0,ADsum1)
 
-split1 = splitSums(ADsum1,k_ind,5)
+split1 = split_sums(ADsum1,k_ind,5)
 @test split1 isa SymbolicUtils.Mul
 @test isequal(5,arguments(split1)[1])
 @test isequal(N_modes/5,arguments(split1)[2].metadata.sumIndex.rangeN)
 
-split2 = splitSums(ADsum1,i_ind,5)
+split2 = split_sums(ADsum1,i_ind,5)
 @test split2 isa SymbolicUtils.Mul
 @test isequal(5,arguments(split2)[1])
 @test isequal(N_atoms/5,arguments(split2)[2].metadata.innerSum.metadata.sumIndex.rangeN)

--- a/test/test_index_basic.jl
+++ b/test/test_index_basic.jl
@@ -58,14 +58,14 @@ sum3 = IndexedSingleSum(a'*σ(1,2,i_ind) + a*σ(2,1,i_ind),i_ind)
 @test isequal(0,Σ(σ(2,1,i_ind)*σ(2,1,i_ind),i_ind))
 
 k_ind = indT(:k)
-Γij = DoubleIndexedVariable(:Γ,i_ind,j_ind,true)
+Γij = DoubleIndexedVariable(:Γ,i_ind,j_ind)
 
-@test(isequal(changeIndex(Γij,j_ind,k_ind), DoubleIndexedVariable(:Γ,i_ind,k_ind,true)))
-@test(isequal(changeIndex(σ(1,2,j_ind)*σ(1,2,i_ind),j_ind,i_ind),0))
-@test(isequal(changeIndex(g(k_ind),k_ind,j_ind),g(j_ind)))
+@test(isequal(change_index(Γij,j_ind,k_ind), DoubleIndexedVariable(:Γ,i_ind,k_ind)))
+@test(isequal(change_index(σ(1,2,j_ind)*σ(1,2,i_ind),j_ind,i_ind),0))
+@test(isequal(change_index(g(k_ind),k_ind,j_ind),g(j_ind)))
 
 @test(isequal(
-    orderByIndex(σ(1,2,k_ind)*σ(1,2,j_ind)*σ(1,2,i_ind),[i_ind]), σ(1,2,i_ind)*σ(1,2,k_ind)*σ(1,2,j_ind)
+    order_by_index(σ(1,2,k_ind)*σ(1,2,j_ind)*σ(1,2,i_ind),[i_ind]), σ(1,2,i_ind)*σ(1,2,k_ind)*σ(1,2,j_ind)
     ))
 
 @test(isequal(
@@ -173,9 +173,9 @@ asdf2 = σ(1,2,k_ind)*specTerm
 @test isequal(simplify(commutator(σ(1,2,i_ind),qadd)),0)
 @test isequal(simplify(commutator(σ(1,2,i_ind),qmul)),0)
 
-Ωij = DoubleIndexedVariable(:Ω,i_ind,j_ind,false)
+Ωij = DoubleIndexedVariable(:Ω,i_ind,j_ind;can_have_same=false)
 
-@test changeIndex(Ωij,i_ind,j_ind) == 0
+@test change_index(Ωij,i_ind,j_ind) == 0
 @test reorder(qc.QAdd([]),[(i_ind,j_ind)]) == 0
 @test reorder(qc.QAdd([0]),[(i_ind,j_ind)]) == 0
 @test reorder(qc.QAdd([σ(1,2,i_ind),σ(2,1,j_ind)]),[(i_ind,j_ind)]) isa qc.QAdd

--- a/test/test_indexed_correlation.jl
+++ b/test/test_indexed_correlation.jl
@@ -23,7 +23,7 @@ l = Index(h,:l,N,ha)
 m = Index(h,:m,N,ha)
 n = Index(h,:n,N,ha)
 
-extraIndices = [n]
+extra_indices = [n]
 
 @qnumbers a::Destroy(h)
 
@@ -36,7 +36,7 @@ H = -Δ*a'a + g*(Σ(a'*σ(1,2,k),k) + Σ(a*σ(2,1,k),k))
 J = [a,σ(1,2,l),σ(2,1,l),σ(2,2,l)]
 rates = [κ, Γ, R, ν]
 ops = [a'*a,σ(2,2,m)]
-eqs = indexedMeanfield(ops,H,J;rates=rates,order=order)
+eqs = indexed_meanfield(ops,H,J;rates=rates,order=order)
 
 @test length(eqs) == 2
 
@@ -50,8 +50,8 @@ eqs = indexedMeanfield(ops,H,J;rates=rates,order=order)
 φ(x::AvgSums) = φ(arguments(x))
 phase_invariant(x) = iszero(φ(x))
 
-eqs_c = complete(eqs;filter_func=phase_invariant,scaling=false,extraIndices=extraIndices);
-eqs_c2 = complete(eqs;filter_func=phase_invariant,scaling=false,extraIndices=[:n]);
+eqs_c = complete(eqs;filter_func=phase_invariant,scaling=false,extra_indices=extra_indices);
+eqs_c2 = complete(eqs;filter_func=phase_invariant,scaling=false,extra_indices=[:n]);
 
 eqs_sc1 = scale(eqs_c)
 eqs_sc2 = scale(eqs_c2)
@@ -66,18 +66,18 @@ end
 
 avrgSum = arguments(arguments(eqs_c[1].rhs)[1])[2]
 
-split0 = splitSums(avrgSum,l,15)
+split0 = split_sums(avrgSum,l,15)
 
 @test isequal(split0,avrgSum)
 
-split1 = splitSums(avrgSum,k,4)
+split1 = split_sums(avrgSum,k,4)
 
 @test split1 isa SymbolicUtils.Mul
 @test !isequal(split1,avrgSum)
 @test isequal(4,arguments(split1)[1])
 @test isequal(N/4,arguments(split1)[2].metadata.sumIndex.rangeN)
 
-split2 = splitSums(avrgSum,k,M)
+split2 = split_sums(avrgSum,k,M)
 
 @test !isequal(split2,split1)
 @test !isequal(split2,avrgSum)
@@ -86,12 +86,12 @@ split2 = splitSums(avrgSum,k,M)
 
 avrgSum2 = arguments(arguments(eqs_c[3].rhs)[1])[2]
 
-_split0 = splitSums(avrgSum2,l,15)
+_split0 = split_sums(avrgSum2,l,15)
 
 @test isequal(avrgSum2,_split0)
-@test isequal(avrgSum2,splitSums(avrgSum2,k,1))
+@test isequal(avrgSum2,split_sums(avrgSum2,k,1))
 
-_split1 = splitSums(avrgSum2,k,3)
+_split1 = split_sums(avrgSum2,k,3)
 
 @test !isequal(_split1,avrgSum2)
 @test _split1 isa SymbolicUtils.Add
@@ -100,7 +100,7 @@ _split1 = splitSums(avrgSum2,k,3)
 op1 = a'
 op2 = a
 
-corr = indexedCorrelationFunction(a', a, eqs_c; steady_state=true, filter_func=phase_invariant,extraIndices=extraIndices,scaling=true);
+corr = IndexedCorrelationFunction(a', a, eqs_c; steady_state=true, filter_func=phase_invariant,extra_indices=extra_indices,scaling=true);
 
 ps = [N, Δ, g, κ, Γ, R, ν]
 
@@ -118,8 +118,8 @@ evals = evaluate(eqs_c;mapping=mapping)
 i = Index(h,:i,N_,ha)
 j = Index(h,:j,N_,ha)
 
-Γ_ij = DoubleIndexedVariable(:Γ,i,j,true)
-Ω_ij = DoubleIndexedVariable(:Ω,i,j,false)
+Γ_ij = DoubleIndexedVariable(:Γ,i,j)
+Ω_ij = DoubleIndexedVariable(:Ω,i,j;can_have_same=false)
 gi = IndexedVariable(:g,i)
 
 ΓMatrix = [1.0 1.0
@@ -135,7 +135,7 @@ ps = [Γ_ij,Ω_ij,gi,κ]
 p0 = [ΓMatrix,ΩMatrix,gn,κn]
 
 mapping = Dict{SymbolicUtils.Sym,Int64}(N_=>2)
-valmap = createMap(ps,p0;mapping=mapping)
+valmap = value_map(ps,p0;mapping=mapping)
 
 map_ = Dict{SymbolicUtils.Sym{Parameter, Base.ImmutableDict{DataType, Any}},ComplexF64}()
 push!(map_,qc.DoubleNumberedVariable(:Γ,1,1)=>1.0)
@@ -163,7 +163,7 @@ end
 
 sum_ = average(Σ(σ(2,1,i)*σ(1,2,j),i))
 
-split = splitSums(sum_,i,3)
+split = split_sums(sum_,i,3)
 
 @test split isa SymbolicUtils.Add
 @test length(arguments(split)) == 3

--- a/test/test_indexed_meanfield.jl
+++ b/test/test_indexed_meanfield.jl
@@ -20,15 +20,15 @@ k_ind = Index(h,:k,N,ha)
 
 #define indexed variables
 g(k) = IndexedVariable(:g,k)
-Γ_ij = DoubleIndexedVariable(:Γ,i_ind,j_ind,true)
-Ω_ij = DoubleIndexedVariable(:Ω,i_ind,j_ind,false)
+Γ_ij = DoubleIndexedVariable(:Γ,i_ind,j_ind)
+Ω_ij = DoubleIndexedVariable(:Ω,i_ind,j_ind;can_have_same=false)
 
 @qnumbers a::Destroy(h)
 σ(i,j,k) = IndexedOperator(Transition(h,:σ,i,j),k)
 
 # Hamiltonian
 
-DSum = Σ(Ω_ij*σ(2,1,i_ind)*σ(1,2,j_ind),j_ind,i_ind,true)
+DSum = Σ(Ω_ij*σ(2,1,i_ind)*σ(1,2,j_ind),j_ind,i_ind;non_equal=true)
 
 @test DSum isa IndexedDoubleSum
 @test isequal(Σ(Σ(Ω_ij*σ(2,1,i_ind)*σ(1,2,j_ind),i_ind,[j_ind]),j_ind),DSum)
@@ -42,7 +42,7 @@ J = [a, [σ(1,2,i_ind),σ(1,2,j_ind)] ]
 rates = [κ,Γ_ij]
 
 ops = [a, σ(2,2,k_ind), σ(1,2,k_ind)]
-eqs = indexedMeanfield(ops,H,J;rates=rates,order=order)
+eqs = indexed_meanfield(ops,H,J;rates=rates,order=order)
 
 @test length(eqs) == 3
 
@@ -50,8 +50,8 @@ ind1 = Index(h,:q,N,ha)
 ind2 = Index(h,:r,N,ha)
 ind3 = Index(h,:s,N,ha)
 
-eqs_comp = complete(eqs;extraIndices=[ind1,ind2,ind3])
-eqs_comp2 = complete(eqs;extraIndices=[:q,:r,:s])
+eqs_comp = complete(eqs;extra_indices=[ind1,ind2,ind3])
+eqs_comp2 = complete(eqs;extra_indices=[:q,:r,:s])
 
 for i=1:length(eqs_comp)
     @test isequal(length(arguments(eqs_comp[i].rhs)),length(arguments(eqs_comp2[i].rhs)))
@@ -60,7 +60,7 @@ eqs_ = evaluate(eqs_comp)
 
 @test length(eqs_) == 18
 
-eqs_4 = indexedMeanfield(ops,H,J;rates=rates,order=4)
+eqs_4 = indexed_meanfield(ops,H,J;rates=rates,order=4)
 
 @test length(eqs_4) == length(eqs)
 


### PR DESCRIPTION
renamed most of the exported method names accordingly to the Julia name convention, adjusted the examples in docu accordingly, changed some of the attributes when creating IndexedVariables and DoubleSums to keyword arguments instead.