### PR TITLE
Bug fix for DoubleIndexedVariables

### DIFF
--- a/src/index_average.jl
+++ b/src/index_average.jl
@@ -214,10 +214,10 @@ struct DoubleNumberedVariable <: numberedVariable
         end
         if typeof(numb1) == typeof(numb2) && numb1 isa Int64
             metadata = source_metadata(:Parameter, name)
-            s = SymbolicUtils.Sym{Parameter, typeof(metadata)}(Symbol("$(name)_{$(numb1)$(numb2)}"), metadata)
+            s = SymbolicUtils.Sym{Parameter, typeof(metadata)}(Symbol("$(name)_{$(numb1),$(numb2)}"), metadata)
             return SymbolicUtils.setmetadata(s, MTK.MTKParameterCtx, true)
         else
-            return SymbolicUtils.Sym{Parameter, numberedVariable}(Symbol("$(name)_{$(numb1)$(numb2)}"), new(name,numb1,numb2))
+            return SymbolicUtils.Sym{Parameter, numberedVariable}(Symbol("$(name)_{$(numb1),$(numb2)}"), new(name,numb1,numb2))
         end
     end
 end

--- a/src/index_utils.jl
+++ b/src/index_utils.jl
@@ -28,6 +28,7 @@ end
 IndexedVariable(x,numb::Int64) = SingleNumberedVariable(x,numb)
 IndexedVariable(x,num1::Int64,num2::Int64;kwargs...) = DoubleNumberedVariable(x,num1,num2;kwargs...)
 IndexedVariable(name::Symbol,ind1::Index,ind2::Index;kwargs...) = DoubleIndexedVariable(name,ind1,ind2;kwargs...)
+DoubleIndexedVariable(x,num1::Int64,num2::Int64;kwargs...) = DoubleNumberedVariable(x,num1,num2;kwargs...)
 
 #Numeric Conversion of NumberedOperators
 function to_numeric(op::NumberedOperator,b::QuantumOpticsBase.CompositeBasis; ranges::Vector{Int64}=Int64[],kwargs...)


### PR DESCRIPTION
found and fixed a bug, regarding DoubleIndexedVariables when they get substituted by values. It could happen, that for variables like "G_{1,12}" the value of "G_{11,2}" got inserted.