### PR TITLE
CorrelationFunctions with IndexedOperators

### DIFF
--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -106,7 +106,7 @@ function correlation_u0(c::CorrelationFunction, u_end)
     keys = []
     for j=1:length(lhs)
         l=lhs[j]
-        l_adj = _adjoint(l)
+        l_adj = _inconj(l)
         if l ∈ Set(lhs0)
             i = findfirst(isequal(l), lhs0)
             push!(u0, u_end[i])
@@ -123,7 +123,7 @@ function correlation_u0(c::CorrelationFunction, u_end)
             for i=1:length(lhs0)
                 l_ = substitute(l, Dict(lhs0[i] => u_end[i]))
                 check = !isequal(l_, l)
-                check && (push!(u0, l_); push!(keys, make_var(c.de.equations[i].lhs, τ)); break)
+                check && (push!(u0, l_); push!(keys, make_var(c.de.equations[j].lhs, τ)); break)
             end
             check || error("Could not find initial value for $l !")
         end
@@ -534,11 +534,6 @@ function _build_spec_func(ω, lhs, rhs, a1, a0, steady_vals, ps=[])
     A = [substitute_conj(A_,vs_adj,vs′hash) for A_∈A]
     b = [substitute_conj(b_,vs_adj,vs′hash) for b_∈b]
     c = [substitute_conj(c_,vs_adj,vs′hash) for c_∈c]
-
-    # need to substitute A,b and c using scaleequal
-    A = [_subst_reds(A_,steady_vals) for A_∈A]
-    b = [_subst_reds(b_,steady_vals) for b_∈b]
-    c = [_subst_reds(c_,steady_vals) for c_∈c]
 
     # Keep Symbolics.unflatten_long_ops from stepping into symbolic average
     # functions by substituting. This can be removed once averages store

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -99,7 +99,7 @@ function correlation_u0(c::CorrelationFunction, u_end)
     a1 = c.op2
     subs = Dict(a1=>a0)
     ops = c.de.operators
-    lhs = [average(substitute(op, subs)) for op in ops]
+    lhs = [inorder!(average(substitute(op, subs))) for op in ops]
     u0 = complex(eltype(u_end))[]
     lhs0 = c.de0.states
     τ = MTK.get_iv(c.de)
@@ -505,7 +505,7 @@ function _build_spec_func(ω, lhs, rhs, a1, a0, steady_vals, ps=[])
     s = Dict(a0=>a1)
     ops = [SymbolicUtils.arguments(l)[1] for l in lhs]
 
-    b = [average(substitute(op, s)) for op in ops] # Initial values
+    b = [inorder!(average(substitute(op, s))) for op in ops] # Initial values
     c = [SymbolicUtils.simplify(c_ / (1.0im*ω)) for c_ in _find_independent(rhs, a0)]
     aon0 = acts_on(a0)
     @assert length(aon0)==1
@@ -514,8 +514,8 @@ function _build_spec_func(ω, lhs, rhs, a1, a0, steady_vals, ps=[])
 
     # Substitute <a0> by steady-state average <a>
     s_avg = Dict(average(a0) => average(a1))
-    Ax = [substitute(A, s_avg) for A∈Ax]
-    c = [substitute(c_, s_avg) for c_∈c]
+    Ax = [inorder!(substitute(A, s_avg)) for A∈Ax]
+    c = [inorder!(substitute(c_, s_avg)) for c_∈c]
 
     # Compute symbolic A column-wise by substituting unit vectors into element-wise form of A*x
     A = Matrix{Any}(undef, length(Ax), length(Ax))
@@ -523,7 +523,7 @@ function _build_spec_func(ω, lhs, rhs, a1, a0, steady_vals, ps=[])
         subs_vals = zeros(length(Ax))
         subs_vals[i] = 1
         subs = Dict(lhs .=> subs_vals)
-        A_i = [SymbolicUtils.simplify(substitute(Ax[j],subs)) for j=1:length(Ax)]
+        A_i = [inorder!(SymbolicUtils.simplify(substitute(Ax[j],subs))) for j=1:length(Ax)]
         A[:,i] = A_i
     end
 

--- a/src/diffeq.jl
+++ b/src/diffeq.jl
@@ -57,3 +57,61 @@ function MTK.ODESystem(me::AbstractMeanfieldEquations, iv=me.iv; kwargs...)
     eqs = MTK.equations(me)
     return MTK.ODESystem(eqs, iv; kwargs...)
 end
+
+const AbstractIndexedMeanfieldEquations = Union{IndexedMeanfieldEquations,EvaledMeanfieldEquations}
+
+function MTK.ODESystem(me::AbstractIndexedMeanfieldEquations, iv=me.iv; kwargs...)
+    eqs = MTK.equations(me)
+    return MTK.ODESystem(eqs, iv; kwargs...)
+end
+
+function MTK.equations(me::AbstractIndexedMeanfieldEquations)
+    # Get the MTK variables
+    varmap = me.varmap
+    vs = MTK.states(me)
+    vhash = map(hash, vs)
+
+    # Substitute conjugate variables by explicit conj
+    vs′ = map(_inconj, vs)
+    vs′hash = map(hash, vs′)
+    i = 1
+    while i <= length(vs′)
+        if vs′hash[i] ∈ vhash
+            deleteat!(vs′, i)
+            deleteat!(vs′hash, i)
+        else
+            i += 1
+        end
+    end
+    rhs = [substitute_conj_ind(eq.rhs, vs′, vs′hash) for eq∈me.equations]
+
+    # Substitute to MTK variables on rhs
+    subs = Dict(varmap)
+    rhs = [substitute(r, subs) for r∈rhs]
+    vs_mtk = getindex.(varmap, 2)
+
+    # Return equations
+    t = MTK.get_iv(me)
+    D = MTK.Differential(t)
+    return [Symbolics.Equation(D(vs_mtk[i]), rhs[i]) for i=1:length(vs)]
+end
+
+# Substitute conjugate variables for indexed equations
+function substitute_conj_ind(t,vs′,vs′hash)
+    if SymbolicUtils.istree(t)
+        if t isa Average
+            if hash(t)∈vs′hash
+                t′ = _inconj(t)
+                return conj(t′)
+            else
+                return t
+            end
+        else
+            _f = x->substitute_conj_ind(x,vs′,vs′hash)
+            args = map(_f, SymbolicUtils.arguments(t))
+            return SymbolicUtils.similarterm(t, SymbolicUtils.operation(t), args)
+        end
+    else
+        return t
+    end
+end

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -78,6 +78,44 @@ struct IndexedMeanfieldEquations <: AbstractMeanfieldEquations #these are for ea
     order::Union{Int,Vector{<:Int},Nothing}
 end
 
+"""
+    EvaledMeanfieldEquations <: AbstractMeanfieldEquations
+
+Type defining a system of differential equations, where `lhs` is a vector of
+derivatives and `rhs` is a vector of expressions. In addition, it keeps track
+of the Hamiltonian, the collapse operators and the corresponding decay rates of
+the system. Similar to [`MeanfieldEquations`](@ref), specialized for equations,
+that are evaluated using the [`evaluate`](@ref) function.
+
+# Fields
+*`equations`: Vector of the differential equations of averages.
+*`operator_equations`: Vector of the operator differential equations.
+*`states`: Vector containing the averages on the left-hand-side of the equations.
+*`operators`: Vector containing the operators on the left-hand-side of the equations.
+*`hamiltonian`: Operator defining the system Hamiltonian.
+*`jumps`: Vector of operators specifying the decay processes.
+*`jumps_dagger`: Vector of operators specifying the adjoint of the decay processes.
+*`rates`: Decay rates corresponding to the `jumps`.
+*`iv`: The independent variable (time parameter) of the system.
+*`varmap`: Vector of pairs that map the averages to time-dependent variables.
+    That format is necessary for ModelingToolkit functionality.
+*`order`: The order at which the [`cumulant_expansion`](@ref) has been performed.
+
+"""
+struct EvaledMeanfieldEquations <: AbstractMeanfieldEquations
+    equations::Vector{Symbolics.Equation}
+    operator_equations::Vector{Symbolics.Equation}
+    states::Vector
+    operators::Vector{QNumber}
+    hamiltonian::QNumber
+    jumps::Vector
+    jumps_dagger
+    rates::Vector
+    iv::SymbolicUtils.BasicSymbolic
+    varmap::Vector{Pair}
+    order::Union{Int,Vector{<:Int},Nothing}
+end
+
 Base.getindex(de::AbstractMeanfieldEquations, i::Int) = de.equations[i]
 Base.getindex(de::AbstractMeanfieldEquations, i) = de.equations[i]
 Base.lastindex(de::AbstractMeanfieldEquations) = lastindex(de.equations)
@@ -98,6 +136,13 @@ function substitute(de::T,dict) where T<:AbstractMeanfieldEquations
     states = getfield.(eqs, :lhs)
     fields = [getfield(de, s) for s∈fieldnames(T)[4:end]]
     return T(eqs, de.operator_equations, states, fields...)
+end
+
+function substitute(de::IndexedMeanfieldEquations,dict)
+    eqs = [Symbolics.Equation(inorder!(substitute(eq.lhs, dict)),inorder!(substitute(eq.rhs, dict))) for eq∈de.equations]
+    states = getfield.(eqs, :lhs)
+    fields = [getfield(de, s) for s∈fieldnames(IndexedMeanfieldEquations)[4:end]]
+    return IndexedMeanfieldEquations(eqs, de.operator_equations, states, fields...)
 end
 
 # Simplification

--- a/src/index_meanfield.jl
+++ b/src/index_meanfield.jl
@@ -577,6 +577,9 @@ end
 function checkAndChange(missed_,sum,extras,states,checking,scaling;kwargs...)
     meta = SymbolicUtils.metadata(sum)[IndexedAverageSum]
     avrgs = getAvrgs(sum) #get vector of all avrgs in the sum
+    if avrgs isa Average
+        avrgs = [avrgs]
+    end
     for avr in avrgs
         changed_ = nothing
         avrg_inds = get_indices(avr)

--- a/src/qnumber.jl
+++ b/src/qnumber.jl
@@ -318,7 +318,7 @@ end
 
 
 ## Hilbert space checks
-check_hilbert(a::QNumber,b::QNumber) = (hilbert(a) == hilbert(b)) || error("Incompatible Hilbert spaces $(a.hilbert) and $(b.hilbert)!")
+check_hilbert(a::QNumber,b::QNumber) = (hilbert(a) == hilbert(b)) || error("Incompatible Hilbert spaces $(hilbert(a)) and $(hilbert(b))!")
 check_hilbert(x,y) = nothing
 
 hilbert(a::QSym) = a.hilbert

--- a/test/test_indexed_correlation.jl
+++ b/test/test_indexed_correlation.jl
@@ -126,6 +126,46 @@ corr = scale(corr)
 corr_nss = IndexedCorrelationFunction(a', a, eqs_c; steady_state=false, filter_func=phase_invariant);
 corr_nss_sc = scale(corr_nss)
 
+op1 = σ(1,2,m)
+op2 = σ(2,1,n)
+
+corr2 = CorrelationFunction(op1, op2, eqs_c) 
+corr2_sc = scale(corr);
+
+p0_c2 = correlation_p0(corr2_sc, sol.u[end],ps.=>p0)
+u0_c2 = correlation_u0(corr2_sc, sol.u[end])
+@named csys2 = ODESystem(corr2_sc) # 5 equations, 8 parameters
+
+prob_c2 = ODEProblem(csys2,u0_c2,(0.0,5.0),p0_c2)
+sol_c2 = solve(prob_c2,Tsit5();saveat=0.001,maxiters=1e8);
+
+@test sol_c2.retcode == SciMLBase.ReturnCode.Success
+
+# Test system with no filter func to evaluate corr function
+
+eqs_c_2 = complete(eqs);
+eqs_ev = evaluate(eqs_c_2;limits=(N=>3))
+
+u0_ev = zeros(ComplexF64, length(eqs_ev))
+
+@named sys_ev = ODESystem(eqs_ev)
+prob_ev = ODEProblem(sys_ev,u0_ev,(0.0, 1.0/50Γ_), ps.=>p0);
+
+sol_ev = solve(prob_ev,Tsit5(),maxiters=1e7)
+@test sol_ev.retcode == SciMLBase.ReturnCode.Success
+
+corr3 = CorrelationFunction(op1, op2, eqs_c_2)
+corr3_ev = evaluate(corr3,1,2; limits=(N=>3));
+
+p0_c3 = correlation_p0(corr3_ev, sol_ev.u[end],ps.=>p0)
+u0_c3 = correlation_u0(corr3_ev, sol_ev.u[end])
+@named csys3 = ODESystem(corr3_ev) 
+
+prob_c3 = ODEProblem(csys3,u0_c3,(0.0,5.0),p0_c3)
+sol_c3 = solve(prob_c3,Tsit5();saveat=0.001,maxiters=1e8);
+
+@test sol_c3.retcode == SciMLBase.ReturnCode.Success
+
 ps = [N, Δ, g, κ, Γ, R, ν]
 
 @test length(corr.de0) == 4
@@ -141,10 +181,10 @@ sol_ss = solve(prob_ss, DynamicSS(Tsit5(); abstol=1e-8, reltol=1e-8),
 p0_c = correlation_p0(corr_nss_sc, sol.u[end],ps.=>p0)
 u0_c = correlation_u0(corr_nss_sc, sol.u[end])
 
-@named csys = ODESystem(corr_nss_sc) # 5 equations, 8 parameters
+@named csys = ODESystem(corr_nss_sc) 
 
 prob_c = ODEProblem(csys,u0_c,(0.0,10.0),p0_c);
-sol_c = solve(prob_c,Tsit5();saveat=0.001,maxiters=1e8); #UndefVarError: avg not defined
+sol_c = solve(prob_c,Tsit5();saveat=0.001,maxiters=1e8); 
 
 @test sol_c.retcode == SciMLBase.ReturnCode.Success
 

--- a/test/test_indexed_correlation.jl
+++ b/test/test_indexed_correlation.jl
@@ -129,8 +129,8 @@ corr_nss_sc = scale(corr_nss)
 op1 = σ(1,2,m)
 op2 = σ(2,1,n)
 
-corr2 = CorrelationFunction(op1, op2, eqs_c) 
-corr2_sc = scale(corr);
+corr2 = CorrelationFunction(op1, op2, eqs_c; filter_func = phase_invariant) 
+corr2_sc = scale(corr2);
 
 p0_c2 = correlation_p0(corr2_sc, sol.u[end],ps.=>p0)
 u0_c2 = correlation_u0(corr2_sc, sol.u[end])
@@ -191,6 +191,13 @@ sol_c = solve(prob_c,Tsit5();saveat=0.001,maxiters=1e8);
 limits = Dict{SymbolicUtils.BasicSymbolic,Int64}(N=>5)
 evals = evaluate(eqs_c;limits=limits)
 
+corr4 = CorrelationFunction(op1, op2, eqs_c; filter_func = phase_invariant, steady_state=true) 
+corr4_sc = scale(corr4);
+
+S4_sc = Spectrum(corr4_sc, ps)
+ω = [-10:0.01:10;]Γ_
+S4_sc(ω,sol_ss.u,p0)
+S4_sc(ω,sol.u[end],p0)
 
 @test length(evals) == 21
 @test length(unique(evals.states)) == length(evals.states)
@@ -301,6 +308,64 @@ h_ = h1⊗h2
 new_sum = qc._new_operator(sum1,h_)
 @test isequal(qc.hilbert(new_sum),h_)
 
+# Test that checks for correct spectrum, when using multiple indexed Hilbert spaces
+# Hamiltonian is based on the indexed superrad laser
+    hc = FockSpace(:cavity)
+    hA = NLevelSpace(:atomA,2)
+    hB = NLevelSpace(:atomB,2)
+    h = hc ⊗ hA ⊗ hB
+    # operators
+    @qnumbers a::Destroy(h)
+    σA(α,β,i) = IndexedOperator(Transition(h,Symbol("σ_a"), α, β, 2),i)
+    σB(α,β,i) = IndexedOperator(Transition(h,Symbol("σ_b"), α, β, 3),i)
+    @cnumbers N Δ κ Γ R ν
+    g(i) = IndexedVariable(:g, i)
+    i = Index(h,:i,N,hA)
+    j = Index(h,:j,N,hA)
+    x = Index(h,:x,N,hB)
+    y = Index(h,:y,N,hB)
+    # Hamiltonian
+    H = -Δ*a'a + Σ(g(i)*( a'*σA(1,2,i) + a*σA(2,1,i) ),i) + Σ(σA(1,2,i)*σB(2,1,x) + σA(2,1,i)*σB(1,2,x),i,x) + Σ(g(x)*( a'*σB(1,2,x) + a*σB(2,1,x) ),x)
 
+    # Jump operators wth corresponding rates
+    J = [a, σA(1,2,i), σA(2,1,i), σA(2,2,i), σB(1,2,x), σB(2,1,x), σB(2,2,x)]
+    rates = [κ, Γ, R, ν, Γ, R, ν]
+    # Derive equations
+    ops = [a'*a, σA(2,2,j)]
+    eqs = meanfield(ops,H,J;rates=rates,order=2);
+    eqs_c = complete(eqs);
+    eqs_sc = scale(eqs_c);
+    @named sys = ODESystem(eqs_sc)
+    # Initial state
+    u0 = zeros(ComplexF64, length(eqs_sc))
+    # System parameters
+    N_ = 2e5
+    Γ_ = 1.0 #Γ=1mHz
+    Δ_ = 2500Γ_ #Δ=2.5Hz
+    g_ = 1000Γ_ #g=1Hz
+    κ_ = 5e6*Γ_ #κ=5kHz
+    R_ = 1000Γ_ #R=1Hz
+    ν_ = 1000Γ_ #ν=1Hz
+    ps = [N, Δ, g(1), κ, Γ, R, ν]
+    p0 = [N_, Δ_, g_, κ_, Γ_, R_, ν_]
+    prob = ODEProblem(sys,u0,(0.0, 1.0/50Γ_), ps.=>p0)
+    # Solve the numeric problem
+    sol = solve(prob,Tsit5(),maxiters=1e7);
+    b = Index(h,:b,N,hA)
+    lims = (N=>2)
+    op1 = σA(1,2,j)
+    op2 = σA(2,1,b)
+    corr = CorrelationFunction(op1, op2, eqs_c; steady_state=true) 
+    corr_sc = scale(corr;limits=lims);
+    S_sc = Spectrum(corr_sc, ps)
+    ω = [-10:0.01:10;]Γ_
+    S_sc(ω,sol.u[end],p0);
+    prob_ss = SteadyStateProblem(prob)
+    sol_ss = solve(prob_ss, DynamicSS(Tsit5(); abstol=1e-8, reltol=1e-8),
+        reltol=1e-14, abstol=1e-14, maxiters=5e7);
+
+    @test sol.retcode == SciMLBase.ReturnCode.Success
+    @test sol_ss.retcode == SciMLBase.ReturnCode.Success
+# end of testcase
 
 end

--- a/test/test_indexed_scale.jl
+++ b/test/test_indexed_scale.jl
@@ -104,7 +104,7 @@ j2 = Index(h_,:j,N,ha_);
 Sz_(i) = ∑(σ2(2,2,i) - σ2(3,3,i),i)
 Sz2 = average(Sz_(i2)*Sz_(j2))
 
-@test isequal(scale(Sz2),average(N*average(σ2(3,3,1)) + N*σ2(2,2,1)) + (-1+N)^2*average(σ2(2,2,1)*σ2(2,2,2)) +
-    (-1+N)^2*average(σ2(3,3,1)*σ2(3,3,2)) -2*(-1+N)^2*average(σ2(3,3,1)*σ2(2,2,2)))
+@test QuantumCumulants.isscaleequal(scale(Sz2),average(N*average(σ2(3,3,1)) + N*σ2(2,2,1)) + (-1+N)^2*average(σ2(2,2,1)*σ2(2,2,2)) +
+    (-1+N)^2*average(σ2(3,3,1)*σ2(3,3,2)) -2*(-1+N)^2*average(σ2(2,2,1)*σ2(3,3,2)))
 
 end


### PR DESCRIPTION
- added possibility to create a CorrelationFunction with IndexedOperators as op1 and op2
- added possbility to evaluate CorrelationFunction
- added a dispatch for MTK.ODESystem for indexed equations, since conjugate substituation is different
- a CorrelationFunction can now be evaluated using a specified NumberedOperator by calling evaluate with additional number parameters
- added test cases for the above

This update should also solve the issues 157,160 and 161