### PR TITLE
compat with SymbolicUtils and TermInterface v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/build
 /examples/
 /.vscode/
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ QuantumOpticsBase = "0.4, 0.5"
 SciMLBase = "1, 2"
 SymbolicUtils = "1, 2"
 Symbolics = "5"
-TermInterface = "0.4, 1, 2"
+TermInterface = "0.4"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ QuantumOpticsBase = "0.4, 0.5"
 SciMLBase = "1, 2"
 SymbolicUtils = "1, 2"
 Symbolics = "5"
-TermInterface = "0.4, 1"
+TermInterface = "0.4, 1, 2"
 julia = "1.6"
 
 [extras]

--- a/src/average.jl
+++ b/src/average.jl
@@ -23,13 +23,13 @@ function _average(operator)
     return SymbolicUtils.Term{AvgSym}(sym_average, [operator])
 end
 # ensure that BasicSymbolic{<:AvgSym} are only single averages
-function *(a::Average,b::Average) 
+function *(a::Average,b::Average)
     if isequal(a,b)
         return SymbolicUtils.Mul(CNumber,1,Dict(a=>2))
     end
     return SymbolicUtils.Mul(CNumber,1,Dict(a=>1,b=>1))
 end
-function +(a::Average,b::Average) 
+function +(a::Average,b::Average)
     if isequal(a,b)
         return SymbolicUtils.Add(CNumber,0,Dict(a=>2))
     end
@@ -37,7 +37,7 @@ function +(a::Average,b::Average)
 end
 
 function acts_on(s::SymbolicUtils.Symbolic)
-    if SymbolicUtils.istree(s)
+    if SymbolicUtils.iscall(s)
         f = SymbolicUtils.operation(s)
         if f === sym_average
             return acts_on(SymbolicUtils.arguments(s)[1])
@@ -82,7 +82,7 @@ average(x::SNuN) = x
 average(x,order;kwargs...) = cumulant_expansion(average(x),order;kwargs...)
 
 function undo_average(t)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         f = SymbolicUtils.operation(t)
         if isequal(f,sym_average) # "===" results in false sometimes in Symbolics version > 5
             return SymbolicUtils.arguments(t)[1]
@@ -133,7 +133,7 @@ Optional arguments
 *kwargs...: Further keyword arguments being passed to simplification.
 """
 function cumulant_expansion(x::SymbolicUtils.Symbolic,order::Integer;simplify=true,kwargs...)
-    if SymbolicUtils.istree(x)
+    if SymbolicUtils.iscall(x)
         get_order(x) <= order && return x
         f = SymbolicUtils.operation(x)
         if f===sym_average
@@ -158,7 +158,7 @@ end
 cumulant_expansion(x::Number,order;kwargs...) = x
 
 function cumulant_expansion(x::SymbolicUtils.Symbolic,order;mix_choice=maximum,simplify=true,kwargs...)
-    if SymbolicUtils.istree(x)
+    if SymbolicUtils.iscall(x)
         f = SymbolicUtils.operation(x)
         args = SymbolicUtils.arguments(x)
         cumulants = [cumulant_expansion(arg,order;simplify=simplify,mix_choice=mix_choice) for arg in args]
@@ -319,7 +319,7 @@ julia> get_order(1)
 """
 get_order(avg::Average) = get_order(SymbolicUtils.arguments(avg)[1])
 function get_order(t::SymbolicUtils.Symbolic)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         return maximum(map(get_order, SymbolicUtils.arguments(t)))
     else
         return 0

--- a/src/cnumber.jl
+++ b/src/cnumber.jl
@@ -28,7 +28,7 @@ Base.zero(::Type{Parameter}) = 0
 Base.adjoint(x::SymbolicUtils.Symbolic{<:CNumber}) = conj(x)
 
 # TODO: this doesn't work with just setting Complex for some reason; am I doing this right?
-MTK.concrete_symtype(::Symbolics.BasicSymbolic{T}) where T <: CNumber = ComplexF64
+SymbolicUtils.symtype(::Symbolics.BasicSymbolic{T}) where T <: CNumber = ComplexF64
 
 """
     @cnumbers(ps...)
@@ -133,7 +133,7 @@ Base.adjoint(x::SymbolicUtils.Symbolic{<:RNumber}) = x
 Base.adjoint(x::RNumber) = x
 Base.conj(x::RNumber) = x
 
-MTK.concrete_symtype(::Symbolics.BasicSymbolic{T}) where T<:RNumber = Real
+SymbolicUtils.symtype(::Symbolics.BasicSymbolic{T}) where T<:RNumber = Real
 
 """
     @rnumbers(ps...)

--- a/src/correlation.jl
+++ b/src/correlation.jl
@@ -392,7 +392,7 @@ function _new_operator(t::Transition, h, aon=t.aon; add_subscript=nothing)
 end
 _new_operator(x::Number, h, aon=nothing; kwargs...) = x
 function _new_operator(t, h, aon=nothing; kwargs...)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         args = []
         if isnothing(aon)
             for arg in SymbolicUtils.arguments(t)
@@ -553,7 +553,7 @@ function _build_spec_func(ω, lhs, rhs, a1, a0, steady_vals, ps=[])
 end
 
 function _substitute_vars(t::SymbolicUtils.Symbolic)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         f = SymbolicUtils.operation(t)
         if f === sym_average
             sym = Symbol(string(t))

--- a/src/diffeq.jl
+++ b/src/diffeq.jl
@@ -35,7 +35,7 @@ end
 
 # Substitute conjugate variables
 function substitute_conj(t,vs′,vs′hash)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         if t isa Average
             if hash(t)∈vs′hash
                 t′ = _conj(t)
@@ -104,7 +104,7 @@ end
 
 # Substitute conjugate variables for indexed equations
 function substitute_conj_ind(t,vs′,vs′hash)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         if t isa Average
             if hash(t)∈vs′hash
                 t′ = _inconj(t)

--- a/src/diffeq.jl
+++ b/src/diffeq.jl
@@ -46,7 +46,7 @@ function substitute_conj(t,vs′,vs′hash)
         else
             _f = x->substitute_conj(x,vs′,vs′hash)
             args = map(_f, SymbolicUtils.arguments(t))
-            return SymbolicUtils.maketerm(typeof(t), SymbolicUtils.operation(t), args, SymbolicUtils.promote_symtype(f, args...), TermInterface.metadata(t))
+            return SymbolicUtils.maketerm(typeof(t), SymbolicUtils.operation(t), args, SymbolicUtils.promote_symtype(_f, args...), TermInterface.metadata(t))
         end
     else
         return t

--- a/src/index_double_sums.jl
+++ b/src/index_double_sums.jl
@@ -71,7 +71,7 @@ function DoubleSum(innerSum::SingleSum,sum_index::Index,NEI::Vector;metadata=NO_
         end
 end
 function DoubleSum(innerSum::IndexedAdd,sum_index::Index,NEI::Vector;metadata=NO_METADATA)
-    if istree(innerSum)
+    if iscall(innerSum)
         op = operation(innerSum)
         if op === +
             sums = [DoubleSum(arg,sum_index,NEI;metadata=metadata) for arg in arguments(innerSum)]
@@ -120,7 +120,7 @@ function *(elem::IndexedObSym,sum::DoubleSum)
     NEI = copy(sum.NEI)
     if elem.ind != sum.sum_index && elem.ind ∉ NEI
         if (sum.sum_index.aon != sum.innerSum.sum_index.aon) # indices for different ops
-            if isequal(elem.ind.aon,sum.sum_index.aon) 
+            if isequal(elem.ind.aon,sum.sum_index.aon)
                 push!(NEI,elem.ind)
                 addterm = SingleSum(elem*change_index(sum.innerSum.term,sum.sum_index,elem.ind),sum.innerSum.sum_index,sum.innerSum.non_equal_indices)
                 return DoubleSum(elem*sum.innerSum,sum.sum_index,NEI) + addterm
@@ -131,7 +131,7 @@ function *(elem::IndexedObSym,sum::DoubleSum)
         ds_term = DoubleSum(SingleSum(elem*sum.innerSum.term,sum.innerSum.sum_index,[sum.innerSum.non_equal_indices...,elem.ind]),sum.sum_index,NEI_)
         new_non_equal_indices1 = replace(sum.NEI, sum.innerSum.sum_index => elem.ind)
         ss_term1 = SingleSum(elem*change_index(sum.innerSum.term,sum.innerSum.sum_index,elem.ind),sum.sum_index,new_non_equal_indices1)
-        new_non_equal_indices2 = replace(sum.innerSum.non_equal_indices, sum.sum_index => elem.ind) 
+        new_non_equal_indices2 = replace(sum.innerSum.non_equal_indices, sum.sum_index => elem.ind)
         ss_term2 = SingleSum(elem*change_index(sum.innerSum.term,sum.sum_index,elem.ind),sum.innerSum.sum_index,new_non_equal_indices2)
         return ds_term + ss_term1 + ss_term2
     end
@@ -141,7 +141,7 @@ function *(sum::DoubleSum,elem::IndexedObSym)
     NEI = copy(sum.NEI)
     if elem.ind != sum.sum_index && elem.ind ∉ NEI
         if (sum.sum_index.aon != sum.innerSum.sum_index.aon) # indices for different ops
-            if isequal(elem.ind.aon,sum.sum_index.aon) 
+            if isequal(elem.ind.aon,sum.sum_index.aon)
                 push!(NEI,elem.ind)
                 addterm = SingleSum(change_index(sum.innerSum.term,sum.sum_index,elem.ind)*elem,sum.innerSum.sum_index,sum.innerSum.non_equal_indices)
                 return DoubleSum(sum.innerSum*elem,sum.sum_index,NEI) + addterm
@@ -152,7 +152,7 @@ function *(sum::DoubleSum,elem::IndexedObSym)
         ds_term = DoubleSum(SingleSum(sum.innerSum.term*elem,sum.innerSum.sum_index,[sum.innerSum.non_equal_indices...,elem.ind]),sum.sum_index,NEI_)
         new_non_equal_indices1 = replace(sum.NEI, sum.innerSum.sum_index => elem.ind)
         ss_term1 = SingleSum(change_index(sum.innerSum.term,sum.innerSum.sum_index,elem.ind)*elem,sum.sum_index,new_non_equal_indices1)
-        new_non_equal_indices2 = replace(sum.innerSum.non_equal_indices, sum.sum_index => elem.ind) 
+        new_non_equal_indices2 = replace(sum.innerSum.non_equal_indices, sum.sum_index => elem.ind)
         ss_term2 = SingleSum(change_index(sum.innerSum.term,sum.sum_index,elem.ind)*elem,sum.innerSum.sum_index,new_non_equal_indices2)
         return ds_term + ss_term1 + ss_term2
     end #with else it does not work?
@@ -163,7 +163,7 @@ end
 *(sum::DoubleSum,x) = DoubleSum(sum.innerSum*x,sum.sum_index,sum.NEI)
 *(x,sum::DoubleSum) = DoubleSum(x*sum.innerSum,sum.sum_index,sum.NEI)
 
-SymbolicUtils.istree(a::DoubleSum) = false
+SymbolicUtils.iscall(a::DoubleSum) = false
 SymbolicUtils.arguments(a::DoubleSum) = SymbolicUtils.arguments(a.innerSum)
 checkInnerSums(sum1::DoubleSum, sum2::DoubleSum) = ((sum1.innerSum + sum2.innerSum) == 0)
 reorder(dsum::DoubleSum,indexMapping::Vector{Tuple{Index,Index}}) = DoubleSum(reorder(dsum.innerSum,indexMapping),dsum.sum_index,dsum.NEI)
@@ -195,4 +195,3 @@ function *(sum1::SingleSum,sum2::SingleSum; ind=nothing)
 
     end
 end
-

--- a/src/index_meanfield.jl
+++ b/src/index_meanfield.jl
@@ -83,7 +83,7 @@ function indexed_meanfield(a::Vector,H,J;Jdagger::Vector=adjoint.(J),rates=ones(
                     end
                 end
                 rhs[i] = reorder((rhs_+rhs_diss),mapping)
-            end    
+            end
         catch err
             println("could not calculate meanfield-equations for operator $(a[i])")
             rethrow(err)
@@ -176,7 +176,7 @@ function indexed_master_lindblad(a_,J,Jdagger,rates)
                     push_or_append_nz_args!(args, c1)
                     push_or_append_nz_args!(args, c2)
                 end
-            else 
+            else
                 error("Unknown rates type!")
             end
         end
@@ -262,7 +262,7 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
         order_ = order
     end
 
-    if order isa Vector 
+    if order isa Vector
         order_max = maximum(order)
     else
         if order === nothing
@@ -276,11 +276,11 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
     num_ind_hilbert = length(unique([ind.aon for ind in get_indices([de.hamiltonian,de.jumps, de.jumps_dagger])]))
 
     if order_max*num_ind_hilbert > num_inds
-        error("Too few extra_indices provided! Please make sure that for higher orders of cumulant expansion, 
+        error("Too few extra_indices provided! Please make sure that for higher orders of cumulant expansion,
             you also use the extra_indices argument to provide additional indices for calculation. The Number of
             extra_indices provided should be at least $(order_max - num_inds).")
     end
-    
+
     maximum(order_) >= order_lhs || error("Cannot form cumulant expansion of derivative; you may want to use a higher order!")
 
     if order_ != de.order
@@ -298,7 +298,7 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
     if containsMultiple(allInds) && extra_indices[1] isa Symbol
         dic = split_inds(allInds)
         filter!(x->!isempty(last(x)),dic)
-        dic2 = Dict{Int,Any}(i => Any[] for i in keys(dic)) 
+        dic2 = Dict{Int,Any}(i => Any[] for i in keys(dic))
         for k in keys(dic)
             dic2[k] = filter(x->isequal(x.aon,k),indices_lhs)
             ind = allInds[findfirst(x->isequal(x.aon,k),allInds)]
@@ -347,7 +347,7 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
 
     end
 
-    #at this point extras is a list of extra_indices, sorted by their priority 
+    #at this point extras is a list of extra_indices, sorted by their priority
     # (meaning that indices that were used in the ops of in indexed_meanfield come first)
 
     vhash = map(hash, vs)
@@ -412,7 +412,7 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
 
         filter!(x -> (x isa Average),missed)
         isnothing(filter_func) || filter!(filter_func, missed) # User-defined filter
-    
+
         filter!(x -> filterComplete(x,de.states,scaling;kwargs...), missed)
         missed = inorder!.(missed)
 
@@ -433,13 +433,13 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
                 end
             end
         end
-    
+
         missed = inorder!.(missed)
         missed = unique(missed)
         missed = filter!(x -> filterComplete(x,de.states,scaling;kwargs...), missed)
         missed = inorder!.(missed)
         missed = elimRed!(missed;scaling=scaling,kwargs...)
-        
+
     end
 
     if !isnothing(filter_func)
@@ -448,7 +448,7 @@ function indexed_complete!(de::AbstractMeanfieldEquations;
         missed = find_missing(de.equations, vhash, vs′hash; get_adjoints=false)
         missed = find_missing_sums(missed,de;extra_indices=extras,checking=false,kwargs...) #checkin dissabled, since there might be some terms, that are redundant, but also zero -> set them to zero aswell forsa fety
         missed = find_missing_Dsums(missed,de;extra_indices=extras,checking=false,kwargs...)
-        missed = find_missing_sums(missed,de;checking=false,kwargs...) 
+        missed = find_missing_sums(missed,de;checking=false,kwargs...)
         missed = find_missing_Dsums(missed,de;checking=false,kwargs...)
 
         missed = inorder!.(missed) #this one might not be right (?) -> not even needed i think
@@ -507,7 +507,7 @@ function get_all_indices(me::AbstractMeanfieldEquations)
         end
     end
     for ind in get_indices(me.hamiltonian)
-        if ind ∉ inds 
+        if ind ∉ inds
             push!(inds,ind)
         end
     end
@@ -581,7 +581,7 @@ function find_missing_sums(missed,de::AbstractMeanfieldEquations;extra_indices::
             extras_filtered = filterExtras(meta.sum_index,extras) #all the extraIndices, that have the same specific hilbertspace as the sum
             checkAndChange(missed_,sum,extras_filtered,de.states,checking,scaling;kwargs...)
         end
-    end 
+    end
     return inorder!.(missed_)
 end
 #this function might not be so fast
@@ -614,7 +614,7 @@ function checkAndChange(missed_,sum,extras,states,checking,scaling;kwargs...)
         if changed_ === nothing #if avrg consists of none indexed operators, or only of operators that already have the desired indices -> push along the whole average
             changed_ = avr
         end
-        
+
         if changed_ isa Average
             changed = inorder!(changed_)    # this can be done, since terms inside the sum commute anyway
             if !(changed isa Average)
@@ -651,8 +651,8 @@ function checkAndChangeDsum(missed_,sum,extras,states,checking,scaling;kwargs...
         end
         if innerInd in avrg_inds
             filtered = filterExtras(innerInd,extras)
-            for i = 1:length(filtered)    
-                if filtered[i] ∉ avrg_inds 
+            for i = 1:length(filtered)
+                if filtered[i] ∉ avrg_inds
                     changed_ = change_index(avr,innerInd,filtered[i])
                     break
                 end
@@ -683,7 +683,7 @@ function filterExtras(wanted,extras)
     return filter(x -> isequal(x.aon,wanted.aon),extras)
 end
 
-function find_missing!(missed,missed_hashes,term::BasicSymbolic{SpecialIndexedAverage},vhash,vshash;kwargs...) 
+function find_missing!(missed,missed_hashes,term::BasicSymbolic{SpecialIndexedAverage},vhash,vshash;kwargs...)
     meta = SymbolicUtils.metadata(term)[SpecialIndexedAverage]
     return find_missing!(missed,missed_hashes,meta.term,vhash,vshash;kwargs...)
 end
@@ -694,7 +694,7 @@ function checkIfSum(term)
     sums = Any[]
     if term isa BasicSymbolic{IndexedAverageSum}
         return copy([term])
-    elseif istree(term)
+    elseif iscall(term)
         args = copy(arguments(term))
         for arg in args
             sums = vcat(sums,checkIfSum(arg))
@@ -704,7 +704,7 @@ function checkIfSum(term)
 end
 function getDSums(term)
     Dsums = Any[]
-    if istree(term)
+    if iscall(term)
         for arg in arguments(term)
             Dsums = vcat(Dsums,getDSums(arg))
         end
@@ -757,7 +757,7 @@ function elimRed!(missed::Vector;scaling::Bool=false,kwargs...)
 end
 
 complete(eqs::IndexedMeanfieldEquations;kwargs...) = indexed_complete(eqs;kwargs...)
-complete!(eqs::IndexedMeanfieldEquations;kwargs...) = indexed_complete!(eqs;kwargs...) 
+complete!(eqs::IndexedMeanfieldEquations;kwargs...) = indexed_complete!(eqs;kwargs...)
 
 """
     evaluate(eqs::IndexedMeanfieldEquations;limits)
@@ -794,7 +794,7 @@ function evaluate(eqs::IndexedMeanfieldEquations;limits=nothing,h=nothing,kwargs
             end
         end
         h = h_
-    end    
+    end
     if !=(limits,nothing) && limits isa Pair
         limits_ = Dict{BasicSymbolic,Int64}(first(limits) => last(limits));
         limits = limits_
@@ -804,7 +804,7 @@ function evaluate(eqs::IndexedMeanfieldEquations;limits=nothing,h=nothing,kwargs
     end
     return subst_reds_eval(evalME(eqs;limits=limits,h=h,kwargs...);limits=limits,h=h,kwargs...)
 end
-function evaluate(term;limits=nothing,kwargs...) 
+function evaluate(term;limits=nothing,kwargs...)
     if !=(limits,nothing) && limits isa Pair
         limits_ = Dict{BasicSymbolic,Int64}(first(limits) => last(limits));
         limits = limits_

--- a/src/index_scale.jl
+++ b/src/index_scale.jl
@@ -62,7 +62,7 @@ function scale_term(pow::SymbolicUtils.Pow; kwargs...)
     return scale_term(args[1]; kwargs...)^(args[2])
 end
 function scale_term(add::BasicSymbolic{<:CNumber}; h=nothing, kwargs...)
-    if istree(add)
+    if iscall(add)
         op = operation(add)
         if op === +
             args = arguments(add)
@@ -71,7 +71,7 @@ function scale_term(add::BasicSymbolic{<:CNumber}; h=nothing, kwargs...)
                 adds[i] = scale_term(args[i]; h=h, kwargs...)
             end
             return sum(adds)
-        elseif op === * 
+        elseif op === *
             mul = add
             mults = []
             for arg in arguments(mul)
@@ -238,7 +238,7 @@ function split_sums(term::SymbolicUtils.BasicSymbolic,ind::Index,amount::Union{<
     if term isa Average
         return term
     end
-    if SymbolicUtils.istree(term)
+    if SymbolicUtils.iscall(term)
         args = []
         op = SymbolicUtils.operation(term)
         for i = 1:length(arguments(term))
@@ -296,6 +296,6 @@ function split_sums(me::AbstractMeanfieldEquations,ind::Index,amount)
 end
 split_sums(x,ind,amount) = x
 
-function scale(args...; kwargs...) 
+function scale(args...; kwargs...)
     return subst_reds_scale(scale_term(args...; kwargs...);kwargs...)
 end

--- a/src/index_utils.jl
+++ b/src/index_utils.jl
@@ -7,7 +7,7 @@ function get_indices(term::QMul)
 end
 get_indices(a::IndexedOperator) = [a.ind]
 get_indices(vec::Vector) = unique(vcat(get_indices.(vec)...))
-function get_indices(a::BasicSymbolic{DoubleIndexedVariable}) 
+function get_indices(a::BasicSymbolic{DoubleIndexedVariable})
     meta = SymbolicUtils.metadata(a)[DoubleIndexedVariable]
     return unique([meta.ind1,meta.ind2])
 end
@@ -17,7 +17,7 @@ const Sums = Union{SingleSum,DoubleSum}
 get_indices(x::SingleSum) = get_indices(x.term)
 get_indices(x::DoubleSum) = get_indices(x.innerSum.term)
 get_indices(x::Number) = []
-get_indices(term) = istree(term) ? get_indices(arguments(term)) : []
+get_indices(term) = iscall(term) ? get_indices(arguments(term)) : []
 
 #Usability functions:
 Σ(a,b) = DoubleSum(a,b)  #Double-Sum here, because if variable a is not a single sum it will create a single sum anyway
@@ -77,7 +77,7 @@ function _inconj(v::Average)
     return _average(adj_arg)
 end
 function _inconj(v::SymbolicUtils.BasicSymbolic)
-    if SymbolicUtils.istree(v)
+    if SymbolicUtils.iscall(v)
         f = SymbolicUtils.operation(v)
         args = map(_inconj, SymbolicUtils.arguments(v))
         return SymbolicUtils.similarterm(v, f, args)
@@ -110,7 +110,7 @@ function inorder!(q::QMul)
     return merge_commutators(q.arg_c,q.args_nc)
 end
 function inorder!(v::SymbolicUtils.BasicSymbolic)
-    if SymbolicUtils.istree(v)
+    if SymbolicUtils.iscall(v)
         f = SymbolicUtils.operation(v)
         args = map(inorder!, SymbolicUtils.arguments(v))
         return SymbolicUtils.similarterm(v, f, args)
@@ -233,7 +233,7 @@ function isscaleequal(a::IndexedOperator,b::IndexedOperator;h=nothing,kwargs...)
     end
 end
 function isscaleequal(t1,t2;kwargs...)
-    if SymbolicUtils.istree(t1) && SymbolicUtils.istree(t2)
+    if SymbolicUtils.iscall(t1) && SymbolicUtils.iscall(t2)
         args1 = arguments(t1)
         args2 = arguments(t2)
         isequal(operation(t1),operation(t2)) || return false

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -166,7 +166,7 @@ const IndexedAdd = Union{QAdd, BasicSymbolic{<:CNumber}}
 const IndexedObSym = Union{IndexedOperator,BasicSymbolic{IndexedVariable},BasicSymbolic{DoubleIndexedVariable}}
 
 function SpecialIndexedTerm(term::IndexedAdd,indexMapping)
-    if istree(term)
+    if iscall(term)
         op = operation(term)
         args = arguments(term)
         return op([reorder(arg,indexMapping) for arg in args]...)
@@ -181,7 +181,7 @@ function SingleSum(term::IndexedObSym,sum_index::Index,non_equal_indices;metadat
     return SingleSum(term,sum_index,non_equal_indices,metadata)
 end
 function SingleSum(term::IndexedAdd, sum_index, non_equal_indices;metadata=NO_METADATA)
-    if istree(term)
+    if iscall(term)
         op = operation(term)
         args = arguments(term)
         if op === +
@@ -645,8 +645,8 @@ function change_index(op::BasicSymbolic{DoubleIndexedVariable},from::Index,to::I
         end
     end
 end
-function change_index(term::BasicSymbolic{<:CNumber},from::Index,to::Index) 
-    if istree(term)
+function change_index(term::BasicSymbolic{<:CNumber},from::Index,to::Index)
+    if iscall(term)
         op = operation(term)
         if op === +
             args = arguments(term)
@@ -678,11 +678,11 @@ function change_index(term::BasicSymbolic{<:CNumber},from::Index,to::Index)
     return term
 end
 # issue 196: TODO:test
-function change_index(S::SingleSum, i::Index, j::Index) 
+function change_index(S::SingleSum, i::Index, j::Index)
     (j ∈ S.non_equal_indices) && error("Index $(j) is in the non-equal index list.")
     if S.sum_index == i
         return SingleSum(change_index(S.term,i,j), j, replace(S.non_equal_indices, i=>j), S.metadata)
-    end        
+    end
     return S
 end
 change_index(x,from::Index,to::Index) = x
@@ -693,7 +693,7 @@ getIndName(op::IndexedOperator) = op.ind.name
 getIndName(ind::Index) = ind.name
 getIndName(x) = Symbol()
 
-SymbolicUtils.istree(a::SingleSum) = false
+SymbolicUtils.iscall(a::SingleSum) = false
 SymbolicUtils.arguments(a::SingleSum) = SymbolicUtils.arguments(a.term)
 SymbolicUtils.arguments(a::IndexedOperator) = [a]
 

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -208,7 +208,7 @@ _to_expression(t::QAdd) = :( +($(_to_expression.(t.arguments)...)) )
 
 _to_expression(p::Parameter) = p.name
 function _to_expression(s::SymbolicUtils.Symbolic)
-    if SymbolicUtils.istree(s)
+    if SymbolicUtils.iscall(s)
         f = SymbolicUtils.operation(s)
         fsym = if isequal(f,sym_average) # "===" results in false for symbolics version 5
             :AVG

--- a/src/qnumber.jl
+++ b/src/qnumber.jl
@@ -42,9 +42,9 @@ Base.isless(a::QSym, b::QSym) = a.name < b.name
 ## Interface for SymbolicUtils
 
 TermInterface.head(::QNumber) = :call
-SymbolicUtils.istree(::QSym) = false
-SymbolicUtils.istree(::QTerm) = true
-SymbolicUtils.istree(::Type{T}) where {T<:QTerm} = true
+SymbolicUtils.iscall(::QSym) = false
+SymbolicUtils.iscall(::QTerm) = true
+SymbolicUtils.iscall(::Type{T}) where {T<:QTerm} = true
 
 # Symbolic type promotion
 SymbolicUtils.promote_symtype(f, Ts::Type{<:QNumber}...) = promote_type(Ts...)

--- a/src/scale.jl
+++ b/src/scale.jl
@@ -5,7 +5,7 @@
 Function, that evaluates a given [`MeanfieldEquations`](@ref) or [`CorrelationFunction`](@ref) entity and returns again equations,
 where indices have been inserted and sums evaluated, regarding the same relations, as done when calculating
 with oparators using a [`ClusterSpace`](@ref). For this it is considered that all entities in the given
-(sub)system are acting on the system equivalently. 
+(sub)system are acting on the system equivalently.
 
 # Arguments
 *`me::IndexedMeanfieldEquations`: A [`MeanfieldEquations`](@ref) entity, which shall be scaled.
@@ -29,7 +29,7 @@ function scale(eqs::IndexedMeanfieldEquations;h=nothing,kwargs...)
             end
         end
         h = h_
-    end    
+    end
     return subst_reds_scale(scaleME(eqs;h=h,kwargs...);h=h,kwargs...)
 end
 function scale(he::AbstractMeanfieldEquations; kwargs...)
@@ -251,7 +251,7 @@ function substitute_redundants(he::MeanfieldEquations,scale_aons::Vector{<:Vecto
 end
 
 function substitute_redundants(t::SymbolicUtils.Symbolic,scale_aons::Vector{<:Vector},names)
-    if SymbolicUtils.istree(t)
+    if SymbolicUtils.iscall(t)
         f = SymbolicUtils.operation(t)
         if f === sym_average
             op = deepcopy(SymbolicUtils.arguments(t)[1])

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,7 +36,7 @@ function find_missing(me::AbstractMeanfieldEquations; vs_adj=nothing, get_adjoin
 end
 
 function find_missing!(missed, missed_hashes, r::SymbolicUtils.Symbolic, vhash, vs′hash; get_adjoints=true)
-    if SymbolicUtils.istree(r)
+    if SymbolicUtils.iscall(r)
         for arg∈SymbolicUtils.arguments(r)
             find_missing!(missed, missed_hashes, arg, vhash, vs′hash; get_adjoints=get_adjoints)
         end
@@ -524,7 +524,7 @@ function _conj(v::Average)
     end
 end
 function _conj(v::SymbolicUtils.Symbolic)
-    if SymbolicUtils.istree(v)
+    if SymbolicUtils.iscall(v)
         f = SymbolicUtils.operation(v)
         args = map(_conj, SymbolicUtils.arguments(v))
         return SymbolicUtils.similarterm(v, f, args)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -326,7 +326,7 @@ end
 
 _to_numeric(op::Destroy, b::QuantumOpticsBase.FockBasis; kwargs...) = QuantumOpticsBase.destroy(b)
 _to_numeric(op::Create, b::QuantumOpticsBase.FockBasis; kwargs...) = QuantumOpticsBase.create(b)
-function _to_numeric(op::Pauli, b::QuantumOpticsBase.SpinBasis; kwargs...) 
+function _to_numeric(op::Pauli, b::QuantumOpticsBase.SpinBasis; kwargs...)
     (b.spinnumber ≠ 1/2) && error("The SpinBasis needs to be Spin-1/2!")
     axis = op.axis
     if axis == 1 # σx
@@ -497,7 +497,7 @@ for T ∈ [:AbstractTimeseriesSolution,:AbstractNoTimeSolution]
         t = MTK.get_iv(ode_func.sys)
         vars = SciMLBase.getsyms(sol)
         var = make_var(avg, t)
-        
+
         if any(isequal(var), vars)
             # sucess, we found the symbol
             return getindex(sol, var)
@@ -548,7 +548,7 @@ for linear combinations of operators, which is not possible with `sol[op]`.
 """
 get_solution(sol, op::QNumber) = sol[op]
 function get_solution(sol, x)
-    if length(sol[1]) == 1 #SteadyStateProblem
+    if length(sol[:,1]) == 1 #SteadyStateProblem
         return x
     else
         return x*ones(length(sol))

--- a/test/test_average_sums.jl
+++ b/test/test_average_sums.jl
@@ -76,8 +76,8 @@ avrgTerm = average(Σ(σ(2,1,ind(:i))*σ(1,2,ind(:j)),ind(:i)))
 @test avrgTerm isa SymbolicUtils.BasicSymbolic && operation(avrgTerm) === +
 ADsum1 = qc.IndexedAverageDoubleSum(avrgTerm,ind(:j),[ind(:i)])
 @test ADsum1 isa SymbolicUtils.BasicSymbolic && operation(ADsum1) === +
-@test SymbolicUtils.metadata(arguments(ADsum1)[1])[qc.IndexedAverageDoubleSum] isa qc.IndexedAverageDoubleSum  
-@test SymbolicUtils.metadata(arguments(ADsum1)[2])[qc.IndexedAverageSum] isa qc.IndexedAverageSum  
+@test SymbolicUtils.metadata(arguments(ADsum1)[1])[qc.IndexedAverageDoubleSum] isa qc.IndexedAverageDoubleSum
+@test SymbolicUtils.metadata(arguments(ADsum1)[2])[qc.IndexedAverageSum] isa qc.IndexedAverageSum
 
 @test isequal(qc.SpecialIndexedAverage(average(σ(1,2,ind(:i))),[(ind(:i),ind(:j))])+qc.SpecialIndexedAverage(average(σ(2,1,ind(:j))),[(ind(:i),ind(:j))]),
 qc.SpecialIndexedAverage(average(σ(1,2,ind(:i))) + average(σ(2,1,ind(:j))),[(ind(:i),ind(:j))]))
@@ -91,14 +91,14 @@ qc.SpecialIndexedAverage(average(σ(1,2,ind(:i))) + average(σ(2,1,ind(:j))),[(i
 @test σ(1,2,ind(:i))*σ(2,1,ind(:j))*σn(2,2,3) isa qc.QMul
 @test σn(2,2,3)*σ(1,2,ind(:i))*σ(2,1,ind(:j)) isa qc.QMul
 
-# @test SymbolicUtils.istree(sum_A.metadata) == false
+# @test SymbolicUtils.iscall(sum_A.metadata) == false
 @test qc.IndexedAverageSum(1) == 1
 
 specAvrg = qc.SpecialIndexedAverage(average(σ(2,1,ind(:i))*σ(1,2,ind(:j))),[(ind(:i),ind(:j))])
 
 @test isequal("(i≠1)",qc.writeNeqs([(ind(:i),1)]))
 @test (isequal(SymbolicUtils.arguments(SymbolicUtils.arguments(ADsum1)[1]),SymbolicUtils.arguments(avrgTerm)[1]) || isequal(SymbolicUtils.arguments(SymbolicUtils.arguments(ADsum1)[1]),SymbolicUtils.arguments(avrgTerm)[2]) )
-# SymbolicUtilsv1.4.0 argument order changed 
+# SymbolicUtilsv1.4.0 argument order changed
 @test isequal(SymbolicUtils.arguments(SymbolicUtils.arguments(SymbolicUtils.arguments(ADsum1)[1])),SymbolicUtils.arguments(average(σ(2,1,ind(:i))*σ(1,2,ind(:j)))))
 @test isequal(SymbolicUtils.arguments(specAvrg),SymbolicUtils.arguments(average(σ(2,1,ind(:i))*σ(1,2,ind(:j)))))
 
@@ -112,14 +112,14 @@ push!(dict,(qc.SingleNumberedVariable(:g,2) => 2))
 
 @test isequal(qc.getAvrgs(specAvrg),average(σ(2,1,ind(:i))*σ(1,2,ind(:j))))
 @test (isequal(qc.getAvrgs(SymbolicUtils.arguments(avrgTerm)[1]),average(σ(2,1,ind(:i))*σ(1,2,ind(:j)))) || isequal(qc.getAvrgs(SymbolicUtils.arguments(avrgTerm)[2]),average(σ(2,1,ind(:i))*σ(1,2,ind(:j)))))
-# SymbolicUtilsv1.4.0 argument order changed 
+# SymbolicUtilsv1.4.0 argument order changed
 
 @test isequal(qc.IndexedAverageSum(g(ind(:i)),ind(:i),[]),average(Σ(g(ind(:i)),ind(:i),[])))
 @test qc.IndexedAverageSum(g(ind(:i)),ind(:i),[]) isa SymbolicUtils.BasicSymbolic{qc.IndexedAverageSum}
 
 @test ind(:i) ∈ qc.get_indices(g(ind(:i)))
 
-@cnumbers N_ 
+@cnumbers N_
 ind2(i) = Index(h,i,N_,ha)
 
 N_n = 10
@@ -140,4 +140,3 @@ eva = qc.eval_term(sum3_B;limits=map2)
 @test !(qc.containsIndexedOps(average(a'*a)))
 
 end
-


### PR DESCRIPTION
After this is merged all the compathelper PR can be closed
![image](https://github.com/user-attachments/assets/cef07592-41e6-4b49-ab3e-76e96b905628)
Relevant:
* [similarter vs maketerm](https://github.com/JuliaSymbolics/SymbolicUtils.jl/blob/7a057d69bd2e3877302c36baed1918233d013862/src/rewriters.jl#L186-L196)
* [PR for SymbolicUtils using TermInterface](https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/609)