### PR TITLE
test: add Aqua and JET to tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumCumulants"
 uuid = "35bcea6d-e19f-57db-af74-8011de6c7255"
-version = "0.3.7"
+version = "0.3.8"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -16,20 +16,31 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [compat]
+Aqua = "0.8.9"
 Combinatorics = "1"
+ExplicitImports = "1.10.1"
+OrdinaryDiffEq = "6.90.1"
+JET = "0.9.12"
 LaTeXStrings = "1"
 Latexify = "0.13, 0.14, 0.15, 0.16"
 LinearAlgebra = "1.6"
 MacroTools = "0.5"
 ModelingToolkit = "9"
 QuantumOpticsBase = "0.4, 0.5"
+QuantumOptics = "1.2.1"
 SciMLBase = "1, 2"
 SymbolicUtils = "3.6.0"
 Symbolics = "6"
+SteadyStateDiffEq = "2.4.1"
 TermInterface = "2"
+Test = "1"
+Random = "1"
 julia = "1.6"
 
 [extras]
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
+JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 QuantumOptics = "6e0679c1-51ea-5a7c-ac74-d61b76210b0c"
@@ -38,4 +49,4 @@ SteadyStateDiffEq = "9672c7b4-1e72-59bd-8a11-6ac3964bc41f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["OrdinaryDiffEq", "SteadyStateDiffEq", "ModelingToolkit", "QuantumOptics", "Random", "Test"]
+test = ["OrdinaryDiffEq", "SteadyStateDiffEq", "ModelingToolkit", "QuantumOptics", "Random", "Test", "JET", "ExplicitImports", "Aqua"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 names = [
+    "test_code_quality.jl"
     "test_fock.jl"
     "test_nlevel.jl"
     "test_spin.jl"

--- a/test/test_code_quality.jl
+++ b/test/test_code_quality.jl
@@ -1,0 +1,14 @@
+using QuantumCumulants, Test
+
+@testset "Code linting" begin
+    using JET
+    JET.test_package(QuantumCumulants; target_defined_modules=true)
+end
+
+@testset "Code quality" begin
+    using ExplicitImports, Aqua
+    @test check_no_stale_explicit_imports(QuantumCumulants) == nothing
+    @test check_all_explicit_imports_via_owners(QuantumCumulants) == nothing
+    Aqua.test_ambiguities([QuantumCumulants])
+    Aqua.test_all(QuantumCumulants;ambiguities=false)
+end


### PR DESCRIPTION
As I am planning to make QuantumCumulant a dependency of a package of mine, I think it is a good idea to test QC with Aqua and JET. Their a couple of invalidations and ambiguities. I will try to tackle a couple of those soon.

We also have one piracy with `Base.isless(::Symbol, Nothing)`. It seemed to be used for indexing?

Feel free to also try to solve a couple yourself.