### PR TITLE
perf: add structured moment-polynomial lowering

### DIFF
--- a/benchmark/moment_ir_lowering.jl
+++ b/benchmark/moment_ir_lowering.jl
@@ -1,0 +1,50 @@
+# Stage-separated benchmark for the evaluator-independent MomentIR compiler.
+#
+# Run from the repository root in a fresh Julia process:
+#   QC_BENCH_ORDER=3 julia --project=benchmark benchmark/moment_ir_lowering.jl
+#   QC_BENCH_ORDER=4 julia --project=benchmark benchmark/moment_ir_lowering.jl
+
+using QuantumCumulants
+using Symbolics: @variables
+
+const QC = QuantumCumulants
+const N = 6
+
+function ising_model(order)
+    h = ⊗([PauliSpace(Symbol(:spin, i)) for i in 1:N]...)
+    σx(i) = Pauli(h, :σ, 1, i)
+    σy(i) = Pauli(h, :σ, 2, i)
+    σz(i) = Pauli(h, :σ, 3, i)
+    σm(i) = (σx(i) - 1im * σy(i)) / 2
+    @variables J hx γ
+    H = -J * sum(σz(i) * σz(i + 1) for i in 1:(N - 1)) - hx * sum(σx(i) for i in 1:N)
+    return meanfield(
+        [σz(i) for i in 1:N],
+        H,
+        [σm(i) for i in 1:N];
+        rates = fill(γ, N),
+        order,
+    )
+end
+
+function timed(f)
+    GC.gc()
+    result = @timed f()
+    return result.value, result.time, result.bytes
+end
+
+function report(order)
+    open, meanfield_time, meanfield_bytes = timed(() -> ising_model(order))
+    eqs, complete_time, complete_bytes = timed(() -> complete(open))
+    ir, lowering_time, lowering_bytes = timed(() -> QC._lower_moment_ir(eqs))
+
+    println("MomentIR lowering order=$order equations=$(length(eqs.states))")
+    println("  meanfield time=$(meanfield_time)s allocations=$(meanfield_bytes)")
+    println("  complete time=$(complete_time)s allocations=$(complete_bytes)")
+    println("  lowering time=$(lowering_time)s allocations=$(lowering_bytes)")
+    println("  states=$(length(ir.states)) monomials=$(length(ir.parent)) terms=$(length(ir.monomial))")
+    println("  IR bytes=$(Base.summarysize(ir))")
+    return nothing
+end
+
+report(parse(Int, get(ENV, "QC_BENCH_ORDER", "3")))

--- a/src/QuantumCumulants.jl
+++ b/src/QuantumCumulants.jl
@@ -50,6 +50,11 @@ include("completion.jl")
 include("scaling.jl")
 include("evaluate.jl")
 include("mtk.jl")
+
+# evaluator-independent structured numerical lowering
+include("backends/moment_ir.jl")
+include("backends/moment_poly_lower.jl")
+
 include("correlation.jl")
 include("spectrum.jl")
 

--- a/src/backends/moment_ir.jl
+++ b/src/backends/moment_ir.jl
@@ -1,0 +1,186 @@
+# Structured lowering of completed deterministic cumulant equations.
+#
+# A completed MeanfieldEquations is represented as
+#
+#     duᵢ = Σₖ cₖ(p) mₖ(u)
+#
+# without committing to a numerical execution strategy. Shared monomials form a
+# prefix-closed DAG. Equation rows are stored directly as CSR-like term ranges; this is
+# the mathematical incidence structure, not a SparseArrays storage trick.
+
+abstract type MomentLoweringError <: Exception end
+
+struct NonPolynomialDriftError{T} <: MomentLoweringError
+    eqindex::Int
+    expression::T
+end
+function Base.showerror(io::IO, e::NonPolynomialDriftError)
+    return print(
+        io,
+        "NonPolynomialDriftError: equation $(e.eqindex) contains unsupported " *
+            "state-dependent structure: $(e.expression). The direct moment representation " *
+            "accepts polynomial drift expressions only; use `System(eqs)` for a general " *
+            "symbolic system.",
+    )
+end
+
+struct TimeDependentCoefficientError{T} <: MomentLoweringError
+    coeff::T
+end
+function Base.showerror(io::IO, e::TimeDependentCoefficientError)
+    return print(
+        io,
+        "TimeDependentCoefficientError: coefficient $(e.coeff) depends on the independent " *
+            "variable. Time-dependent coefficients are outside the direct moment " *
+            "representation; use `System(eqs)` for that model.",
+    )
+end
+
+struct UnresolvedMomentError{T} <: MomentLoweringError
+    moment::T
+end
+function Base.showerror(io::IO, e::UnresolvedMomentError)
+    return print(
+        io,
+        "UnresolvedMomentError: the right-hand sides reference the average $(e.moment), " *
+            "which does not resolve to any stored state. Call `complete(eqs)` first, or " *
+            "check that scaling/evaluation produced a closed system.",
+    )
+end
+
+"""
+    MomentIR
+
+Evaluator-independent representation of a completed deterministic moment hierarchy.
+
+`states[i]` identifies row/state `i`. Monomial `1` is the empty product. For `m > 1`,
+`parent[m]` and `leaf[m]` encode `monomial[m] = monomial[parent[m]] * statefactor(leaf[m])`.
+A positive leaf `j` denotes state `j`; a negative leaf `-j` denotes `conj(state[j])`.
+
+Equation `i` owns the term range `rowptr[i]:(rowptr[i + 1] - 1)`. Each term references one
+shared monomial and one pooled symbolic coefficient. Symbolic metadata is intentionally cold:
+numerical evaluators must compile this representation into concrete runtime storage rather
+than inspect `states`, `coeffs`, or `params` on the hot RHS path.
+"""
+struct MomentIR
+    states::Vector{Any}
+    parent::Vector{Int32}
+    leaf::Vector{Int32}
+    rowptr::Vector{Int32}
+    monomial::Vector{Int32}
+    coeff_id::Vector{Int32}
+    coeffs::Vector{Any}
+    params::Vector{Any}
+end
+
+Base.length(ir::MomentIR) = length(ir.states)
+
+"""Map every average leaf occurring in the equations to its signed stored-state index."""
+function _moment_state_indices(eqs::MeanfieldEquations)
+    ctx = build_ctx(eqs)
+    treatments = _treatments(eqs, ctx)
+    ops = QAdd[(o = undo_average(s); o isa QAdd ? o : o * 1) for s in eqs.states]
+    moments = MomentMap(ctx, treatments, ops, collect(Int32, 1:length(ops)))
+
+    idx = Dict{Any, Int32}()
+    for eq in eqs.equations, leaf in eachleaf(Symbolics.unwrap(eq.rhs))
+        haskey(idx, leaf) && continue
+        op = undo_average(leaf)
+        r = match_moment(moments, op isa QAdd ? op : op * 1)
+        r === nothing && throw(UnresolvedMomentError(leaf))
+        i, same = r
+        idx[leaf] = same ? Int32(i) : Int32(-i)
+    end
+    return idx
+end
+
+"""Discover scalar symbolic coefficient dependencies in deterministic order."""
+function _moment_params(coeffs, iv)
+    iv_uw = Symbolics.unwrap(iv)
+    seen = Set{Any}()
+    params = Any[]
+    for coeff in coeffs
+        coeff isa Number && continue
+        for var in Symbolics.get_variables(coeff)
+            u = Symbolics.unwrap(var)
+            isequal(u, iv_uw) && throw(TimeDependentCoefficientError(coeff))
+            # SQA represents the algebraic imaginary unit symbolically. It is a constant,
+            # not a model parameter. A user variable also named `im` remains a parameter
+            # because its symbolic type is not Number.
+            if SymbolicUtils.issym(u) &&
+                    Base.nameof(u) === :im &&
+                    SymbolicUtils.symtype(u) === Number
+                continue
+            end
+            if !(u in seen)
+                push!(seen, u)
+                push!(params, u)
+            end
+        end
+    end
+    sort!(params; by = string)
+    return params
+end
+
+"""
+    _lower_moment_ir(eqs::MeanfieldEquations) -> MomentIR
+
+Lower a completed deterministic hierarchy to its structured polynomial representation.
+The output is independent of parameter values and numerical evaluator choice.
+"""
+function _lower_moment_ir(eqs::MeanfieldEquations)
+    idx = _moment_state_indices(eqs)
+    return _build_moment_ir(eqs, idx)
+end
+
+function _build_moment_ir(eqs::MeanfieldEquations, idx::Dict{Any, Int32})
+    edges = Dict{Tuple{Int32, Int32}, Int32}()
+    parent = Int32[0]
+    leaf = Int32[0]
+
+    coeff_ids = Dict{Any, Int32}()
+    coeffs = Any[]
+    rowptr = Vector{Int32}(undef, length(eqs.equations) + 1)
+    rowptr[1] = Int32(1)
+    monomial = Int32[]
+    coeff_id = Int32[]
+
+    function mono_id!(factors::Tuple)
+        p = Int32(1)
+        @inbounds for factor in factors
+            f = Int32(factor)
+            key = (p, f)
+            p = get!(edges, key) do
+                push!(parent, p)
+                push!(leaf, f)
+                Int32(length(parent))
+            end
+        end
+        return p
+    end
+
+    state_cache = IdDict{Any, Bool}()
+    for (i, eq) in enumerate(eqs.equations)
+        drift = Symbolics.unwrap(eq.rhs)
+        poly = _compile_moment_polynomial(drift, idx, state_cache)
+        poly === nothing && throw(NonPolynomialDriftError(i, drift))
+
+        terms = collect(poly)
+        sort!(terms; by = first)
+        for (factors, coeff) in terms
+            _moment_coeff_iszero(coeff) && continue
+            mid = mono_id!(factors)
+            cid = get!(coeff_ids, coeff) do
+                push!(coeffs, coeff)
+                Int32(length(coeffs))
+            end
+            push!(monomial, mid)
+            push!(coeff_id, cid)
+        end
+        rowptr[i + 1] = Int32(length(monomial) + 1)
+    end
+
+    states = Any[Symbolics.unwrap(s) for s in eqs.states]
+    params = _moment_params(coeffs, eqs.iv)
+    return MomentIR(states, parent, leaf, rowptr, monomial, coeff_id, coeffs, params)
+end

--- a/src/backends/moment_poly_lower.jl
+++ b/src/backends/moment_poly_lower.jl
@@ -1,0 +1,260 @@
+# Recursive sparse-polynomial compiler for MomentIR.
+#
+# The supported grammar is deliberately explicit. State-free subtrees are coefficients;
+# state-dependent sums, products, nonnegative integer powers, unary/binary subtraction, and
+# division by a state-free denominator are polynomial structure. Any other state-dependent
+# operation declines lowering and is reported by the MomentIR builder. There is intentionally
+# no Symbolics.polynomial_coeffs fallback in production.
+
+_unwrap_moment_poly(x::Symbolics.Num) = SymbolicUtils.unwrap(x)
+_unwrap_moment_poly(x) = x
+
+function _moment_state_factor(x, idx)
+    x = _unwrap_moment_poly(x)
+    haskey(idx, x) && return idx[x]
+    if x isa SymbolicUtils.BasicSymbolic && SymbolicUtils.iscall(x)
+        op = SymbolicUtils.operation(x)
+        args = SymbolicUtils.arguments(x)
+        if op === conj && length(args) == 1
+            y = _unwrap_moment_poly(args[1])
+            haskey(idx, y) && return Int32(-idx[y])
+        end
+    end
+    return nothing
+end
+
+function _contains_moment_state(x, idx, cache::IdDict{Any, Bool})
+    x = _unwrap_moment_poly(x)
+    haskey(cache, x) && return cache[x]
+    result = if _moment_state_factor(x, idx) !== nothing
+        true
+    elseif !(x isa SymbolicUtils.BasicSymbolic) || !SymbolicUtils.iscall(x)
+        false
+    else
+        any(a -> _contains_moment_state(a, idx, cache), SymbolicUtils.arguments(x))
+    end
+    cache[x] = result
+    return result
+end
+
+function _nonnegative_integer_exponent(e)
+    e = _unwrap_moment_poly(e)
+    value = if e isa Number
+        e
+    else
+        try
+            SymbolicUtils.unwrap_const(e)
+        catch
+            return nothing
+        end
+    end
+    n = if value isa Integer
+        Int(value)
+    elseif value isa Rational && denominator(value) == 1
+        Int(value)
+    elseif value isa Real && isinteger(value)
+        Int(value)
+    else
+        return nothing
+    end
+    return n < 0 ? nothing : n
+end
+
+"""Conservative zero test local to cold coefficient construction."""
+function _moment_coeff_iszero(coeff)
+    u = _unwrap_moment_poly(coeff)
+    u isa Number && return iszero(u)
+    if u isa SymbolicUtils.BasicSymbolic && SymbolicUtils.isconst(u)
+        return try
+            iszero(SymbolicUtils.unwrap_const(u))
+        catch
+            false
+        end
+    end
+    if u isa SymbolicUtils.BasicSymbolic &&
+            SymbolicUtils.iscall(u) &&
+            SymbolicUtils.operation(u) === (+)
+        expanded = try
+            _unwrap_moment_poly(Symbolics.expand(coeff))
+        catch
+            u
+        end
+        expanded isa Number && return iszero(expanded)
+        if expanded isa SymbolicUtils.BasicSymbolic && SymbolicUtils.isconst(expanded)
+            return try
+                iszero(SymbolicUtils.unwrap_const(expanded))
+            catch
+                false
+            end
+        end
+    end
+    return false
+end
+
+function _merge_moment_factors(a::Tuple, b::Tuple)
+    isempty(a) && return b
+    isempty(b) && return a
+    out = Vector{Int32}(undef, length(a) + length(b))
+    ia = 1
+    ib = 1
+    io = 1
+    while ia <= length(a) && ib <= length(b)
+        if a[ia] <= b[ib]
+            out[io] = a[ia]
+            ia += 1
+        else
+            out[io] = b[ib]
+            ib += 1
+        end
+        io += 1
+    end
+    while ia <= length(a)
+        out[io] = a[ia]
+        ia += 1
+        io += 1
+    end
+    while ib <= length(b)
+        out[io] = b[ib]
+        ib += 1
+        io += 1
+    end
+    return Tuple(out)
+end
+
+function _moment_poly_add_term!(out::Dict{Tuple, Any}, mono::Tuple, coeff)
+    _moment_coeff_iszero(coeff) && return out
+    if haskey(out, mono)
+        value = out[mono] + coeff
+        if _moment_coeff_iszero(value)
+            delete!(out, mono)
+        else
+            out[mono] = value
+        end
+    else
+        out[mono] = coeff
+    end
+    return out
+end
+
+function _moment_poly_add!(out::Dict{Tuple, Any}, p::Dict{Tuple, Any})
+    for (mono, coeff) in p
+        _moment_poly_add_term!(out, mono, coeff)
+    end
+    return out
+end
+
+function _moment_poly_scale(p::Dict{Tuple, Any}, coeff)
+    _moment_coeff_iszero(coeff) && return Dict{Tuple, Any}()
+    isequal(coeff, 1) && return p
+    out = Dict{Tuple, Any}()
+    sizehint!(out, length(p))
+    for (mono, value) in p
+        _moment_poly_add_term!(out, mono, coeff * value)
+    end
+    return out
+end
+
+function _constant_moment_poly_coeff(p::Dict{Tuple, Any})
+    length(p) == 1 || return nothing
+    return get(p, (), nothing)
+end
+
+function _moment_poly_mul(a::Dict{Tuple, Any}, b::Dict{Tuple, Any})
+    isempty(a) && return Dict{Tuple, Any}()
+    isempty(b) && return Dict{Tuple, Any}()
+    ca = _constant_moment_poly_coeff(a)
+    ca === nothing || return _moment_poly_scale(b, ca)
+    cb = _constant_moment_poly_coeff(b)
+    cb === nothing || return _moment_poly_scale(a, cb)
+
+    out = Dict{Tuple, Any}()
+    sizehint!(out, length(a) * length(b))
+    for (ma, caa) in a, (mb, cbb) in b
+        _moment_poly_add_term!(out, _merge_moment_factors(ma, mb), caa * cbb)
+    end
+    return out
+end
+
+function _moment_poly_pow(base::Dict{Tuple, Any}, n::Int)
+    n == 0 && return Dict{Tuple, Any}(() => 1)
+    n == 1 && return base
+    result = Dict{Tuple, Any}(() => 1)
+    power = base
+    k = n
+    while k > 0
+        isodd(k) && (result = _moment_poly_mul(result, power))
+        k >>= 1
+        k == 0 || (power = _moment_poly_mul(power, power))
+    end
+    return result
+end
+
+"""
+    _compile_moment_polynomial(x, idx, state_cache)
+
+Compile `x` to `Dict{Tuple,Any}` mapping canonical signed state-factor tuples to symbolic
+coefficients. Returns `nothing` precisely when a state-dependent subtree is outside the
+supported polynomial grammar.
+"""
+function _compile_moment_polynomial(x, idx, state_cache::IdDict{Any, Bool})
+    x = _unwrap_moment_poly(x)
+
+    j = _moment_state_factor(x, idx)
+    j === nothing || return Dict{Tuple, Any}((Int32(j),) => 1)
+
+    if !_contains_moment_state(x, idx, state_cache)
+        return Dict{Tuple, Any}(() => x)
+    end
+
+    if !(x isa SymbolicUtils.BasicSymbolic) || !SymbolicUtils.iscall(x)
+        return nothing
+    end
+
+    op = SymbolicUtils.operation(x)
+    args = SymbolicUtils.arguments(x)
+
+    if op === (+)
+        out = Dict{Tuple, Any}()
+        for arg in args
+            p = _compile_moment_polynomial(arg, idx, state_cache)
+            p === nothing && return nothing
+            _moment_poly_add!(out, p)
+        end
+        return out
+    elseif op === (*)
+        out = Dict{Tuple, Any}(() => 1)
+        for arg in args
+            p = _compile_moment_polynomial(arg, idx, state_cache)
+            p === nothing && return nothing
+            out = _moment_poly_mul(out, p)
+        end
+        return out
+    elseif op === (-)
+        if length(args) == 1
+            p = _compile_moment_polynomial(args[1], idx, state_cache)
+            p === nothing && return nothing
+            return _moment_poly_scale(p, -1)
+        elseif length(args) == 2
+            a = _compile_moment_polynomial(args[1], idx, state_cache)
+            a === nothing && return nothing
+            b = _compile_moment_polynomial(args[2], idx, state_cache)
+            b === nothing && return nothing
+            return _moment_poly_add!(a, _moment_poly_scale(b, -1))
+        end
+        return nothing
+    elseif op === (^) && length(args) == 2
+        _contains_moment_state(args[2], idx, state_cache) && return nothing
+        n = _nonnegative_integer_exponent(args[2])
+        n === nothing && return nothing
+        base = _compile_moment_polynomial(args[1], idx, state_cache)
+        base === nothing && return nothing
+        return _moment_poly_pow(base, n)
+    elseif op === (/) && length(args) == 2
+        _contains_moment_state(args[2], idx, state_cache) && return nothing
+        numerator = _compile_moment_polynomial(args[1], idx, state_cache)
+        numerator === nothing && return nothing
+        return _moment_poly_scale(numerator, inv(_unwrap_moment_poly(args[2])))
+    end
+
+    return nothing
+end

--- a/test/backends/moment_ir_errors_test.jl
+++ b/test/backends/moment_ir_errors_test.jl
@@ -1,0 +1,25 @@
+using QuantumCumulants
+using Symbolics: Symbolics, @variables
+using Test
+
+const QC = QuantumCumulants
+
+@testset "MomentIR unresolved and time-dependent errors" begin
+    h = PauliSpace(:errors)
+    sx = Pauli(h, :σ, 1)
+    sy = Pauli(h, :σ, 2)
+    sz = Pauli(h, :σ, 3)
+    sm = (sx - 1im * sy) / 2
+    @variables J hx γ
+    H = -J * sz - hx * sx
+
+    open = meanfield([sz], H, [sm]; rates = [γ], order = 2)
+    @test_throws QC.UnresolvedMomentError QC._lower_moment_ir(open)
+
+    closed = complete(open; get_adjoints = true)
+    timed = modify_equations(closed, (op, drift) -> cos(closed.iv) * drift)
+    @test_throws QC.TimeDependentCoefficientError QC._lower_moment_ir(timed)
+
+    nonpoly = modify_equations(closed, (op, drift) -> drift + exp(average(op)))
+    @test_throws QC.NonPolynomialDriftError QC._lower_moment_ir(nonpoly)
+end

--- a/test/backends/moment_ir_test.jl
+++ b/test/backends/moment_ir_test.jl
@@ -1,0 +1,161 @@
+using QuantumCumulants
+using SymbolicUtils: SymbolicUtils
+using Symbolics: Symbolics, @variables
+using Test
+
+const QC = QuantumCumulants
+
+function ir_factor_tuples(ir)
+    factors = Vector{Tuple}(undef, length(ir.parent))
+    factors[1] = ()
+    for m in 2:length(ir.parent)
+        p = Int(ir.parent[m])
+        factors[m] = (factors[p]..., ir.leaf[m])
+    end
+    return factors
+end
+
+function oracle_monomial_factors(mono, idx)
+    fs = Int32[]
+    addfactor(f) = if SymbolicUtils.iscall(f) && SymbolicUtils.operation(f) === (^)
+        base, exponent = SymbolicUtils.arguments(f)
+        n = Int(SymbolicUtils.unwrap_const(exponent))
+        append!(fs, fill(idx[base], n))
+    else
+        push!(fs, idx[f])
+    end
+
+    if mono isa Number || SymbolicUtils.isconst(mono)
+        return ()
+    elseif SymbolicUtils.iscall(mono) && SymbolicUtils.operation(mono) === (*)
+        foreach(addfactor, SymbolicUtils.arguments(mono))
+    else
+        addfactor(mono)
+    end
+    sort!(fs)
+    return Tuple(fs)
+end
+
+function oracle_equation_terms(drift, vars, idx)
+    dict, residual = Symbolics.polynomial_coeffs(drift, vars)
+    @test _is_zero(residual)
+    out = Dict{Tuple, Any}()
+    for (mono, coeff) in dict
+        factors = oracle_monomial_factors(mono, idx)
+        out[factors] = haskey(out, factors) ? out[factors] + coeff : coeff
+    end
+    return out
+end
+
+function ir_equation_terms(ir, row)
+    factors = ir_factor_tuples(ir)
+    out = Dict{Tuple, Any}()
+    for k in ir.rowptr[row]:(ir.rowptr[row + 1] - 1)
+        mono = factors[ir.monomial[k]]
+        coeff = ir.coeffs[ir.coeff_id[k]]
+        out[mono] = haskey(out, mono) ? out[mono] + coeff : coeff
+    end
+    return out
+end
+
+function assert_ir_matches_symbolics(eqs)
+    ir = QC._lower_moment_ir(eqs)
+    idx = QC._moment_state_indices(eqs)
+    vars = collect(keys(idx))
+    @test length(ir.states) == length(eqs.states)
+    @test length(ir.rowptr) == length(eqs.states) + 1
+    @test ir.rowptr[1] == 1
+    @test ir.rowptr[end] == length(ir.monomial) + 1
+
+    for i in eachindex(eqs.equations)
+        got = ir_equation_terms(ir, i)
+        ref = oracle_equation_terms(Symbolics.unwrap(eqs.equations[i].rhs), vars, idx)
+        @test Set(keys(got)) == Set(keys(ref))
+        for mono in keys(ref)
+            @test _is_zero(got[mono] - ref[mono])
+        end
+    end
+    return ir
+end
+
+@testset "MomentIR polynomial oracle — Pauli hierarchy" begin
+    h = PauliSpace(:s)
+    sx = Pauli(h, :σ, 1)
+    sy = Pauli(h, :σ, 2)
+    sz = Pauli(h, :σ, 3)
+    sm = (sx - 1im * sy) / 2
+    @variables Ω γ
+    eqs = meanfield([sz], Ω * sx, [sm]; rates = [γ], order = 2)
+    complete!(eqs; get_adjoints = true)
+
+    ir = assert_ir_matches_symbolics(eqs)
+    ir2 = QC._lower_moment_ir(eqs)
+    @test isequal(ir.states, ir2.states)
+    @test ir.parent == ir2.parent
+    @test ir.leaf == ir2.leaf
+    @test ir.rowptr == ir2.rowptr
+    @test ir.monomial == ir2.monomial
+    @test ir.coeff_id == ir2.coeff_id
+    @test isequal(ir.coeffs, ir2.coeffs)
+    @test isequal(ir.params, ir2.params)
+end
+
+@testset "MomentIR polynomial oracle — folded nonlinear Kerr hierarchy" begin
+    h = FockSpace(:cavity)
+    a = Destroy(h, :a)
+    @variables Δ Ω κ U
+    H = Δ * a' * a + U * a' * a' * a * a + Ω * (a + a')
+    eqs = meanfield([a], H, [a]; rates = [κ], order = 2)
+    complete!(eqs; get_adjoints = false)
+
+    ir = assert_ir_matches_symbolics(eqs)
+    @test any(x -> x < 0, ir.leaf)
+end
+
+@testset "recursive grammar and explicit capability boundary" begin
+    h = PauliSpace(:grammar)
+    sx = Pauli(h, :σ, 1)
+    sy = Pauli(h, :σ, 2)
+    sz = Pauli(h, :σ, 3)
+    sm = (sx - 1im * sy) / 2
+    @variables Ω γ a b
+    eqs = meanfield([sz], Ω * sx, [sm]; rates = [γ], order = 1)
+    complete!(eqs; get_adjoints = true)
+
+    idx = QC._moment_state_indices(eqs)
+    vars = collect(keys(idx))
+    x, y = vars[1], vars[2]
+    cache() = IdDict{Any, Bool}()
+
+    nested = Symbolics.unwrap(a * (x + b * y) * (x - y)^2)
+    @test QC._compile_moment_polynomial(nested, idx, cache()) !== nothing
+    @test QC._compile_moment_polynomial(Symbolics.unwrap((x + y)^2 / a), idx, cache()) !== nothing
+    @test QC._compile_moment_polynomial(Symbolics.unwrap(sin(a)), idx, cache()) !== nothing
+
+    @test QC._compile_moment_polynomial(Symbolics.unwrap(exp(x)), idx, cache()) === nothing
+    @test QC._compile_moment_polynomial(Symbolics.unwrap(x^(-1)), idx, cache()) === nothing
+    @test QC._compile_moment_polynomial(Symbolics.unwrap(x^y), idx, cache()) === nothing
+    @test QC._compile_moment_polynomial(Symbolics.unwrap((x + 1) / y), idx, cache()) === nothing
+
+    nonpoly = modify_equations(eqs, (op, drift) -> drift + exp(average(op)))
+    @test_throws QC.NonPolynomialDriftError QC._lower_moment_ir(nonpoly)
+
+    timed = modify_equations(eqs, (op, drift) -> cos(eqs.iv) * drift)
+    @test_throws QC.TimeDependentCoefficientError QC._lower_moment_ir(timed)
+end
+
+@testset "user parameter named im is distinct from the algebraic imaginary constant" begin
+    h = PauliSpace(:im_parameter)
+    sx = Pauli(h, :σ, 1)
+    sy = Pauli(h, :σ, 2)
+    sz = Pauli(h, :σ, 3)
+    sm = (sx - 1im * sy) / 2
+    @variables Ω γ
+    eqs = meanfield([sz], Ω * sx, [sm]; rates = [γ], order = 1)
+    complete!(eqs; get_adjoints = true)
+
+    imvar = Symbolics.variable(:im)
+    modified = modify_equations(eqs, (op, drift) -> imvar * drift)
+    ir = QC._lower_moment_ir(modified)
+    @test any(p -> isequal(p, Symbolics.unwrap(imvar)), ir.params)
+end


### PR DESCRIPTION
Roadmap: #330

Clean first layer extracted from the successful #333 prototype.

Scope is intentionally limited to `MeanfieldEquations -> MomentIR`: exact state/equation ordering, shared prefix-closed monomials, direct row-term storage, pooled symbolic coefficients and deterministic parameter discovery. Unsupported state-dependent syntax is an explicit `NonPolynomialDriftError`; `Symbolics.polynomial_coeffs` remains test-oracle-only and is not a production fallback.

The production lowering supports state-free coefficient subtrees, states, sums, products, unary/binary subtraction, nonnegative integer powers, and division by state-free denominators. User parameters named `im` remain distinct from the internal SQA imaginary symbol.

No evaluator, SciML integration, Jacobian, threading, sparse runtime matrix, or generated code is included in this layer.