### PR TITLE
perf: add compact serial MomentIR evaluator

### DIFF
--- a/src/QuantumCumulants.jl
+++ b/src/QuantumCumulants.jl
@@ -51,9 +51,10 @@ include("scaling.jl")
 include("evaluate.jl")
 include("mtk.jl")
 
-# evaluator-independent structured numerical lowering
+# structured numerical representation and compact serial execution
 include("backends/moment_ir.jl")
 include("backends/moment_poly_lower.jl")
+include("backends/moment_kernel.jl")
 
 include("correlation.jl")
 include("spectrum.jl")

--- a/src/backends/moment_kernel.jl
+++ b/src/backends/moment_kernel.jl
@@ -1,0 +1,128 @@
+# Compact serial numerical evaluator for MomentIR.
+#
+# This layer contains no symbolic metadata and no SciML integration. A MomentKernel stores
+# only integer execution tables. Numerical coefficient values are supplied separately on
+# each call; parameter binding belongs to the next layer.
+#
+# Scratch is task-local rather than kernel-local. The evaluator never yields, so two serial
+# kernel calls on one task cannot overlap; kernels with the same numeric type and monomial
+# count may therefore reuse one buffer. The package-global TLS key also means completed tasks
+# do not retain discarded kernel objects.
+
+const _MOMENT_SCRATCH_TLS_KEY = Ref{Nothing}()
+const _MomentScratchRegistry = Dict{DataType, Any}
+
+struct _MomentScratchCache{T}
+    buffers::Dict{Int, Vector{T}}
+end
+
+_MomentScratchCache(::Type{T}) where {T} = _MomentScratchCache{T}(Dict{Int, Vector{T}}())
+
+function _moment_scratch_registry()
+    tls = task_local_storage()
+    registry = get(tls, _MOMENT_SCRATCH_TLS_KEY, nothing)
+    if registry === nothing
+        registry = _MomentScratchRegistry()
+        tls[_MOMENT_SCRATCH_TLS_KEY] = registry
+    end
+    return registry::_MomentScratchRegistry
+end
+
+function _moment_scratch_cache(::Type{T}) where {T}
+    registry = _moment_scratch_registry()
+    cache = get(registry, T, nothing)
+    if cache === nothing
+        cache = _MomentScratchCache(T)
+        registry[T] = cache
+    end
+    return cache::_MomentScratchCache{T}
+end
+
+function _moment_buffer(::Type{T}, n::Int) where {T}
+    cache = _moment_scratch_cache(T)
+    buffer = get(cache.buffers, n, nothing)
+    if buffer === nothing
+        buffer = Vector{T}(undef, n)
+        buffer[1] = one(T)
+        cache.buffers[n] = buffer
+    end
+    return buffer::Vector{T}
+end
+
+"""
+    MomentKernel{T}
+
+Concrete serial execution plan compiled from a `MomentIR`. The kernel retains only integer
+monomial/row tables; it does not retain symbolic states, coefficients, parameters, source
+equations, or mutable scratch buffers.
+"""
+struct MomentKernel{T}
+    parent::Vector{Int32}
+    leaf::Vector{Int32}
+    rowptr::Vector{Int32}
+    monomial::Vector{Int32}
+    coeff_id::Vector{Int32}
+end
+
+MomentKernel(ir::MomentIR) = MomentKernel(ir, ComplexF64)
+function MomentKernel(ir::MomentIR, ::Type{T}) where {T <: Number}
+    isconcretetype(T) || throw(ArgumentError("MomentKernel numeric type must be concrete; got $T"))
+    return MomentKernel{T}(ir.parent, ir.leaf, ir.rowptr, ir.monomial, ir.coeff_id)
+end
+
+Base.length(kernel::MomentKernel) = length(kernel.rowptr) - 1
+
+"""Evaluate every shared monomial in prefix order."""
+function _update_monomials!(v::AbstractVector{T}, parent, leaf, u::AbstractVector{T}) where {T}
+    @inbounds v[1] = one(T)
+    @inbounds for m in 2:length(v)
+        j = leaf[m]
+        x = j > 0 ? u[j] : conj(u[-j])
+        v[m] = v[parent[m]] * x
+    end
+    return v
+end
+
+"""Evaluate equation rows from shared monomials and the pooled numeric coefficient vector."""
+function _evaluate_moment_rows!(
+        du::AbstractVector{T},
+        rowptr,
+        monomial,
+        coeff_id,
+        coeffs::AbstractVector{T},
+        v::AbstractVector{T},
+    ) where {T}
+    @inbounds for i in eachindex(du)
+        acc = zero(T)
+        for k in rowptr[i]:(rowptr[i + 1] - 1)
+            acc += coeffs[coeff_id[k]] * v[monomial[k]]
+        end
+        du[i] = acc
+    end
+    return du
+end
+
+"""
+    kernel(du, u, coeffs)
+
+Evaluate the structured RHS in place. `coeffs` is the numeric value of the pooled symbolic
+coefficient table in the source `MomentIR`; parameter binding and refresh are deliberately
+outside this evaluator.
+"""
+function (kernel::MomentKernel{T})(
+        du::AbstractVector{T},
+        u::AbstractVector{T},
+        coeffs::AbstractVector{T},
+    ) where {T}
+    v = _moment_buffer(T, length(kernel.parent))
+    _update_monomials!(v, kernel.parent, kernel.leaf, u)
+    _evaluate_moment_rows!(
+        du,
+        kernel.rowptr,
+        kernel.monomial,
+        kernel.coeff_id,
+        coeffs,
+        v,
+    )
+    return nothing
+end

--- a/test/backends/moment_kernel_test.jl
+++ b/test/backends/moment_kernel_test.jl
@@ -1,0 +1,167 @@
+using QuantumCumulants
+using SymbolicUtils: SymbolicUtils
+using Symbolics: Symbolics, @variables
+using Test
+
+const QC = QuantumCumulants
+
+Base.@constprop :none function allocated_call(f, args::Vararg{Any, N}) where {N}
+    b0 = Ref{Int64}(0)
+    b1 = Ref{Int64}(0)
+    Base.gc_bytes(b0)
+    Base.@noinline f(args...)
+    Base.gc_bytes(b1)
+    return b1[] - b0[]
+end
+
+function numeric_coefficients(ir, pdict)
+    pd = Dict{Any, Any}(Symbolics.unwrap(k) => v for (k, v) in pdict)
+    for coeff in ir.coeffs
+        coeff isa Number && continue
+        for var in Symbolics.get_variables(coeff)
+            u = Symbolics.unwrap(var)
+            if SymbolicUtils.issym(u) &&
+                    Base.nameof(u) === :im &&
+                    SymbolicUtils.symtype(u) === Number
+                pd[u] = im
+            end
+        end
+    end
+    return ComplexF64[
+        ComplexF64(SymbolicUtils.unwrap_const(Symbolics.substitute(coeff, pd))) for
+            coeff in ir.coeffs
+    ]
+end
+
+function reference_du(eqs, pdict, u)
+    subs = Dict{Any, Any}(Symbolics.unwrap(k) => v for (k, v) in pdict)
+    for (i, state) in enumerate(eqs.states)
+        subs[Symbolics.unwrap(state)] = u[i]
+        adj = Symbolics.unwrap(average(adjoint(undo_average(state))))
+        haskey(subs, adj) || (subs[adj] = conj(u[i]))
+    end
+    out = Vector{ComplexF64}(undef, length(eqs.states))
+    for (i, eq) in enumerate(eqs.equations)
+        rhs = Symbolics.unwrap(eq.rhs)
+        for var in Symbolics.get_variables(rhs)
+            uvar = Symbolics.unwrap(var)
+            if SymbolicUtils.issym(uvar) &&
+                    Base.nameof(uvar) === :im &&
+                    SymbolicUtils.symtype(uvar) === Number
+                subs[uvar] = im
+            end
+        end
+        out[i] = ComplexF64(SymbolicUtils.unwrap_const(Symbolics.substitute(rhs, subs)))
+    end
+    return out
+end
+
+function pauli_fixture()
+    n = 3
+    h = ⊗([PauliSpace(Symbol(:spin, i)) for i in 1:n]...)
+    σx(i) = Pauli(h, :σ, 1, i)
+    σy(i) = Pauli(h, :σ, 2, i)
+    σz(i) = Pauli(h, :σ, 3, i)
+    σm(i) = (σx(i) - 1im * σy(i)) / 2
+    @variables J hx γ
+    H = -J * sum(σz(i) * σz(i + 1) for i in 1:(n - 1)) - hx * sum(σx(i) for i in 1:n)
+    eqs = meanfield(
+        [σz(i) for i in 1:n],
+        H,
+        [σm(i) for i in 1:n];
+        rates = fill(γ, n),
+        order = 2,
+    )
+    complete!(eqs)
+    return eqs, Dict(J => 1.0, hx => 1.0, γ => 0.2)
+end
+
+@testset "serial MomentKernel agrees with symbolic substitution" begin
+    eqs, ps = pauli_fixture()
+    ir = QC._lower_moment_ir(eqs)
+    kernel = QC.MomentKernel(ir)
+    coeffs = numeric_coefficients(ir, ps)
+    u = ComplexF64[0.1cos(3.7i) + 0.05im * sin(1.3i) for i in eachindex(eqs.states)]
+    du = similar(u)
+
+    kernel(du, u, coeffs)
+    ref = reference_du(eqs, ps, u)
+    @test maximum(abs.(du .- ref) ./ max.(abs.(ref), 1.0e-12)) < 1.0e-12
+end
+
+@testset "serial MomentKernel handles folded conjugates" begin
+    h = FockSpace(:kernel_cavity)
+    a = Destroy(h, :a)
+    @variables Δ Ω κ U
+    H = Δ * a' * a + U * a' * a' * a * a + Ω * (a + a')
+    eqs = meanfield([a], H, [a]; rates = [κ], order = 2)
+    complete!(eqs; get_adjoints = false)
+    ps = Dict(Δ => -1.0, Ω => 1.3, κ => 1.0, U => 0.1)
+
+    ir = QC._lower_moment_ir(eqs)
+    kernel = QC.MomentKernel(ir)
+    coeffs = numeric_coefficients(ir, ps)
+    u = ComplexF64[0.3cos(2.1i) + 0.2im * sin(0.7i) for i in eachindex(eqs.states)]
+    du = similar(u)
+
+    kernel(du, u, coeffs)
+    @test du ≈ reference_du(eqs, ps, u) rtol = 1.0e-12 atol = 1.0e-12
+end
+
+@testset "MomentKernel hot call is allocation-free after scratch initialization" begin
+    eqs, ps = pauli_fixture()
+    ir = QC._lower_moment_ir(eqs)
+    kernel = QC.MomentKernel(ir)
+    coeffs = numeric_coefficients(ir, ps)
+    u = zeros(ComplexF64, length(eqs.states))
+    du = similar(u)
+
+    kernel(du, u, coeffs)
+    allocated = allocated_call(kernel, du, u, coeffs)
+    @test allocated == 0
+end
+
+@testset "MomentKernel is reentrant across concurrent tasks" begin
+    eqs, ps = pauli_fixture()
+    ir = QC._lower_moment_ir(eqs)
+    kernel = QC.MomentKernel(ir)
+    coeffs = numeric_coefficients(ir, ps)
+    n = length(eqs.states)
+
+    us = [
+        ComplexF64[0.1cos(2.3i + 0.7j) + 0.05im * sin(1.1i - 0.3j) for i in 1:n] for
+            j in 1:8
+    ]
+    refs = map(us) do u
+        du = similar(u)
+        kernel(du, u, coeffs)
+        du
+    end
+
+    mismatches = Threads.Atomic{Int}(0)
+    @sync for _ in 1:100, (u, ref) in zip(us, refs)
+        Threads.@spawn begin
+            du = similar(u)
+            kernel(du, u, coeffs)
+            du == ref || Threads.atomic_add!(mismatches, 1)
+        end
+    end
+    @test mismatches[] == 0
+end
+
+@testset "task-local scratch does not retain discarded kernels" begin
+    function weak_kernel_after_call()
+        eqs, ps = pauli_fixture()
+        ir = QC._lower_moment_ir(eqs)
+        kernel = QC.MomentKernel(ir)
+        weak_kernel = Base.WeakRef(kernel)
+        coeffs = numeric_coefficients(ir, ps)
+        u = zeros(ComplexF64, length(eqs.states))
+        du = similar(u)
+        kernel(du, u, coeffs)
+        kernel = nothing
+        GC.gc()
+        return weak_kernel
+    end
+    @test weak_kernel_after_call().value === nothing
+end

--- a/test/quality/JET.jl
+++ b/test/quality/JET.jl
@@ -47,6 +47,27 @@ end
 
 push!(JET_CALL_THUNKS, "System(damped cavity)" => _jet_to_system_cavity)
 
+const _JET_MOMENT_IR = QuantumCumulants.MomentIR(
+    Any[:u],
+    Int32[0, 1],
+    Int32[0, 1],
+    Int32[1, 2],
+    Int32[2],
+    Int32[1],
+    Any[1],
+    Any[],
+)
+const _JET_MOMENT_KERNEL = QuantumCumulants.MomentKernel(_JET_MOMENT_IR)
+const _JET_MOMENT_U = ComplexF64[0.25 + 0.1im]
+const _JET_MOMENT_COEFFS = ComplexF64[2.0 - 0.5im]
+
+function _jet_moment_kernel_rhs()
+    du = similar(_JET_MOMENT_U)
+    _JET_MOMENT_KERNEL(du, _JET_MOMENT_U, _JET_MOMENT_COEFFS)
+    return du
+end
+
+push!(JET_OPT_THUNKS, "MomentKernel hot RHS" => _jet_moment_kernel_rhs)
 
 @testset "Type Stability (JET)" begin
     @static if isempty(VERSION.prerelease)


### PR DESCRIPTION
Stacks on #335.

This layer adds only `MomentIR -> MomentKernel` serial numerical execution.

The kernel retains integer monomial/row tables only. Symbolic states, symbolic coefficients, parameter binding, SciML integration, Jacobians and threading are intentionally outside this PR.

Key contracts:

- the hot evaluator is a small concrete data pass over shared prefix monomials and contiguous equation rows;
- numerical coefficient values are supplied separately from symbolic `MomentIR` metadata;
- scratch is task-local through one package-global TLS root and a typed per-task cache keyed by numeric type and monomial count, so concurrent tasks are isolated without retaining kernel objects;
- warm RHS evaluation is regression-tested for exactly zero allocations on both Julia 1.10 LTS and current Julia using a call-boundary GC-counter measurement;
- optimizer-level `JET.@report_opt` analysis is a required gate for a representative `MomentKernel` hot call;
- folded conjugate factors are validated against direct symbolic substitution.

The next layer owns parameter binding and SciML `ODEProblem` semantics.