### PR TITLE
perf: reuse closure canonicalization fingerprint

### DIFF
--- a/src/canonical.jl
+++ b/src/canonical.jl
@@ -200,7 +200,13 @@ symmetry of the identical atoms (via `symmetric_min`), and `Concrete` keeps its 
 site labels. Hermitian conjugation is not applied.
 """
 function _treatment_key(op::QAdd, ctx::CanonCtx, treatments::Dict{Int, SubspaceTreatment})
-    return get!(ctx.cache.key, (op, treatment_fp(treatments))) do
+    return _treatment_key(op, ctx, treatments, treatment_fp(treatments))
+end
+
+function _treatment_key(
+        op::QAdd, ctx::CanonCtx, treatments::Dict{Int, SubspaceTreatment}, fp::TreatmentFP,
+    )
+    return get!(ctx.cache.key, (op, fp)) do
         scaled = Set{Int}()
         concrete = Set{Int}()
         for (sp, t) in treatments
@@ -221,6 +227,7 @@ function _treatment_key(op::QAdd, ctx::CanonCtx, treatments::Dict{Int, SubspaceT
     end
 end
 _treatment_key(op, ::CanonCtx, ::Dict{Int, SubspaceTreatment}) = op
+_treatment_key(op, ::CanonCtx, ::Dict{Int, SubspaceTreatment}, ::TreatmentFP) = op
 
 """
 The `k`-th canonical index slot of a subspace, minted from its first declared vocabulary

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -82,6 +82,8 @@ function closure(
         foldable = _alltrue, max_iter::Int = 100_000,
     )
     ctx = g.ctx
+    free_treatments = all_free_treatments(ctx)
+    free_fp = treatment_fp(free_treatments)
     nodes = copy(g.nodes)   # shallow copy: NodeData values are shared (immutable), new moments appended here
     seen = Set(keys(nodes))
     pending = collect(keys(nodes))
@@ -99,9 +101,9 @@ function closure(
         nd = nodes[popfirst!(pending)]
         for leaf in _drift_leaves(nd)
             op = undo_average(leaf)
-            k = canon_key(op, ctx)
+            k = _treatment_key(op, ctx, free_treatments, free_fp)
             k in seen && continue
-            kc = canon_key(adjoint(op), ctx)
+            kc = _treatment_key(adjoint(op), ctx, free_treatments, free_fp)
             if kc in seen && foldable(op)
                 push!(seen, k)
                 continue


### PR DESCRIPTION
## Summary

Reduce repeated canonicalization setup during cumulant-hierarchy closure.

`closure` always canonicalizes newly discovered moments with the all-`Free` treatment. Previously every `canon_key` call rebuilt that treatment map and its sorted `TreatmentFP`. This PR computes the all-`Free` map and fingerprint once per closure pass and reuses them through a private `_treatment_key(..., fp)` overload.

The public API and closure semantics are unchanged. In particular, closure still uses all-`Free` canonicalization even if a graph later carries scaled treatments.

## Benchmark

Fresh-context N=6 dissipative Ising closure, Julia 1.12.7, one thread, three samples per method, exact hierarchy/`NodeData` equality checked on every sample (workflow run `34202157836`):

| order | states | baseline | reused map + fingerprint | allocation change |
|---|---:|---:|---:|---:|
| 3 | 693 | 0.4682 s / 380.6 MB | 0.4693 s / 364.2 MB | -4.3% |
| 4 | 1908 | 2.6306 s / 2.1347 GB | 2.6249 s / 2.0052 GB | -6.1% |

The order-4 wall time is effectively unchanged while allocation volume falls by about 130 MB per fresh closure.

A broader invariant-hoisting experiment also tested precomputing `im * H`; that path was rejected because it was slower and allocated slightly more. This PR contains only the measured-positive canonicalization reuse.

Part of #345.