### PR TITLE
perf: skip and serialize ground reduction

### DIFF
--- a/src/moments.jl
+++ b/src/moments.jl
@@ -199,6 +199,8 @@ function _reduce_ground_in_drift_threadsafe(x)
 end
 
 """Whether an operator expression can produce an N-level ground projector."""
+_may_need_ground_reduction(op::SQA.QSym) = SQA.is_transition(op)
+_may_need_ground_reduction(ops::AbstractVector) = any(_may_need_ground_reduction, ops)
 function _may_need_ground_reduction(q::QAdd)
     for (term, _) in q.arguments, op in term.ops
         SQA.is_transition(op) && return true
@@ -251,7 +253,7 @@ function derive(op::QAdd, sys, ctx::CanonCtx)
             sys.order === nothing ? noise_rhs :
                 cumulant_expansion(noise_rhs, sys.order; mix_choice = sys.mix_choice),
         )
-        if _may_need_ground_reduction(op) || any(_may_need_ground_reduction, sys.jumps)
+        if _may_need_ground_reduction(op) || _may_need_ground_reduction(sys.jumps)
             noise = _reduce_ground_in_drift_threadsafe(noise)
         end
     end

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -185,6 +185,27 @@ function _reduce_ground_in_drift(x)
     end
 end
 
+# `SymbolicUtils.arguments(::AddMul)` lazily fills an internal argument cache.
+# Independent derived drifts can share symbolic subtrees, so the first traversal of
+# one such subtree is not safe to perform concurrently. Keep only this required
+# post-cumulant rewrite serialized; the expensive operator and cumulant work remains
+# parallel.
+const _GROUND_REDUCTION_LOCK = ReentrantLock()
+
+function _reduce_ground_in_drift_threadsafe(x)
+    return lock(_GROUND_REDUCTION_LOCK) do
+        _reduce_ground_in_drift(x)
+    end
+end
+
+"""Whether an operator expression can produce an N-level ground projector."""
+function _may_need_ground_reduction(q::QAdd)
+    for (term, _) in q.arguments, op in term.ops
+        SQA.is_transition(op) && return true
+    end
+    return false
+end
+
 struct NodeData
     drift::Symbolics.Num                      # faithful averaged-and-truncated RHS
     op_drift::QAdd                            # operator RHS (latex / inspection / re-truncation)
@@ -210,7 +231,9 @@ function derive(op::QAdd, sys, ctx::CanonCtx)
     # collapse and leak spurious higher-order cumulants.
     op_drift = _assume_distinct_atom_indices(op_drift, _distinct_atom_indices([op]))
     drift = Symbolics.Num(average_and_truncate(op_drift, sys.order, sys.mix_choice, ctx))
-    drift = _reduce_ground_in_drift(drift)
+    if _may_need_ground_reduction(op_drift)
+        drift = _reduce_ground_in_drift_threadsafe(drift)
+    end
 
     if sys.efficiencies === nothing
         op_noise = nothing
@@ -228,7 +251,9 @@ function derive(op::QAdd, sys, ctx::CanonCtx)
             sys.order === nothing ? noise_rhs :
                 cumulant_expansion(noise_rhs, sys.order; mix_choice = sys.mix_choice),
         )
-        noise = _reduce_ground_in_drift(noise)
+        if _may_need_ground_reduction(op) || any(_may_need_ground_reduction, sys.jumps)
+            noise = _reduce_ground_in_drift_threadsafe(noise)
+        end
     end
 
     return NodeData(drift, op_drift, noise, op_noise, get_order(op), SQA.acts_on(op))

--- a/test/completion/ground_reduction_thread_safety_test.jl
+++ b/test/completion/ground_reduction_thread_safety_test.jl
@@ -15,9 +15,11 @@ const QC = QuantumCumulants
     pk = first(keys(peqs.graph.nodes))
     pnode = QC.derive(pk, peqs.graph.sys, peqs.graph.ctx)
     @test !QC._may_need_ground_reduction(pnode.op_drift)
-    raw = Symbolics.Num(QC.average_and_truncate(
-        pnode.op_drift, peqs.graph.sys.order, peqs.graph.sys.mix_choice, peqs.graph.ctx,
-    ))
+    raw = Symbolics.Num(
+        QC.average_and_truncate(
+            pnode.op_drift, peqs.graph.sys.order, peqs.graph.sys.mix_choice, peqs.graph.ctx,
+        )
+    )
     @test isequal(pnode.drift, raw)
 
     hn = NLevelSpace(:atom, 2)

--- a/test/completion/ground_reduction_thread_safety_test.jl
+++ b/test/completion/ground_reduction_thread_safety_test.jl
@@ -1,0 +1,39 @@
+using QuantumCumulants
+import Symbolics
+using Symbolics: @variables
+using Test
+
+const QC = QuantumCumulants
+
+@testset "ground reduction capability and serialized traversal" begin
+    hp = PauliSpace(:spin)
+    sx = Pauli(hp, :σ, 1)
+    sy = Pauli(hp, :σ, 2)
+    sz = Pauli(hp, :σ, 3)
+    @variables Ω γ
+    peqs = meanfield([sz], Ω * sx, [(sx - 1im * sy) / 2]; rates = [γ], order = 2)
+    pk = first(keys(peqs.graph.nodes))
+    pnode = QC.derive(pk, peqs.graph.sys, peqs.graph.ctx)
+    @test !QC._may_need_ground_reduction(pnode.op_drift)
+    raw = Symbolics.Num(QC.average_and_truncate(
+        pnode.op_drift, peqs.graph.sys.order, peqs.graph.sys.mix_choice, peqs.graph.ctx,
+    ))
+    @test isequal(pnode.drift, raw)
+
+    hn = NLevelSpace(:atom, 2)
+    σ(i, j) = Transition(hn, :σ, i, j)
+    H = Ω * (σ(1, 2) + σ(2, 1))
+    neqs = meanfield([σ(2, 2)], H, [σ(1, 2)]; rates = [γ], order = 2)
+    nk = first(keys(neqs.graph.nodes))
+    nnode = QC.derive(nk, neqs.graph.sys, neqs.graph.ctx)
+    @test QC._may_need_ground_reduction(nnode.op_drift)
+
+    ground = average(σ(1, 1))
+    excited = average(σ(2, 2))
+    shared = Symbolics.Num(ground + 2 * ground * excited + excited^2)
+    tasks = [Threads.@spawn QC._reduce_ground_in_drift_threadsafe(shared) for _ in 1:16]
+    vals = fetch.(tasks)
+    expected = QC._reduce_ground_in_drift(shared)
+    @test !isequal(expected, shared)
+    @test all(x -> isequal(x, expected), vals)
+end

--- a/test/completion/ground_reduction_thread_safety_test.jl
+++ b/test/completion/ground_reduction_thread_safety_test.jl
@@ -29,6 +29,13 @@ const QC = QuantumCumulants
     nk = first(keys(neqs.graph.nodes))
     nnode = QC.derive(nk, neqs.graph.sys, neqs.graph.ctx)
     @test QC._may_need_ground_reduction(nnode.op_drift)
+    @test QC._may_need_ground_reduction(σ(1, 2))
+    @test !QC._may_need_ground_reduction(sx)
+
+    noise_eqs = meanfield(
+        [σ(2, 2)], H, [σ(1, 2)]; rates = [γ], efficiencies = [1], order = 2,
+    )
+    @test first(values(noise_eqs.graph.nodes)).noise !== nothing
 
     ground = average(σ(1, 1))
     excited = average(σ(2, 2))


### PR DESCRIPTION
## Summary

This follows the merged closure-parallelization work and keeps the optimization on `master`, independent of the MomentIR/SciML stack.

- skip post-cumulant ground-projector reduction when the operator expression contains no ordinary N-level `Transition` operators;
- serialize only the required ground-reduction tree traversal;
- leave operator RHS construction and cumulant expansion parallel;
- cover both compound operator expressions and leaf/nested jump storage in the capability gate;
- add focused regressions for the skip path, measurement-noise leaf jumps, and concurrent reduction of a shared unreduced N-level symbolic DAG.

## Why

`_reduce_ground_in_drift` was a pure no-op for Pauli-only closure workloads, but its generic `mapleaves` traversal became a major allocation source at higher cumulant order. During four-thread closure validation, the same traversal also exposed a `ConcurrencyViolationError` in `SymbolicUtils.arguments(::AddMul)`: the argument accessor lazily fills an internal cache, and independently derived drifts can share symbolic subtrees.

The containment here is deliberately narrow: avoid the traversal entirely when it cannot change the result, and otherwise guard only that post-cumulant traversal with a dedicated lock.

The capability test deliberately distinguishes ordinary `Transition` from `CollectiveTransition`: SQA's collective N-level space has no omitted ground-projector convention, so the completeness fold is specific to ordinary N-level transitions. Jump vectors are checked recursively because `SystemSpec` retains leaf `QSym` jumps and can also carry grouped jump vectors.

## Validation

Temporary exact-head validation on Julia 1.12 with 4 threads passed:

- focused ground-reduction regression: 4/4;
- completeness invariant: 9/9;
- existing parallel-closure regression: 3460 + 1091 + 440 + 218 assertions;
- N=6 driven-dissipative Ising, order 4: serial/threaded closure graphs exactly identical, 1908 states.

The production regression is stronger than the temporary one: it runs the guarded reduction concurrently on the same unreduced N-level symbolic DAG and compares all results with the serial reduction. It also constructs a measurement-noise system with a leaf `Transition` jump, covering the `SystemSpec.jumps` representation used by ordinary `meanfield` calls. Normal Tests CI runs with `JULIA_NUM_THREADS=11`.

## Performance evidence

For the N=6 driven-dissipative Ising closure, skipping the no-op ground-reduction traversal preserved the exact graph and reduced order-4 allocation from about 2.10 GB to 1.39 GB (allocation ratio 0.66075), with about 1.27x serial speedup.

On the guarded implementation with four threads:

- order 3: 2.14x versus guarded serial;
- order 4: 1.71x versus guarded serial;
- threaded allocation remained effectively identical to guarded serial (order-4 ratio 1.00005).

Public API and hierarchy semantics are unchanged.

Refs #345