### PR TITLE
ci: restore moving Julia 1 selector

### DIFF
--- a/.github/workflows/JET.yml
+++ b/.github/workflows/JET.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.13'
+          - '1'
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         version:
           - 'lts'
-          - '1.13'
+          - '1'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Restore the current-stable CI lanes from explicit Julia `1.13` back to the moving Julia `1` selector.

The earlier 1.13 support PR unnecessarily pinned jobs that already resolved to Julia 1.13. Using `1` preserves the intended current-stable semantics and will automatically follow future Julia 1.x releases.

This PR only changes the package Tests and JET selectors back to `1`. The JET 0.12 compatibility and `test/Project.toml` workflow trigger added in #357 remain intact.